### PR TITLE
用語統一等のための修正案

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
 <meta name="generator" content="ReSpec 25.4.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <style>
+
+  /* --- for WoT JP --- */
+.mark { background: linear-gradient(transparent 00%, #00ffff 0%);}
+
+
+
   /* --- EXAMPLES --- */
   span.example-title {
     text-transform: none;
@@ -160,7 +166,7 @@
   }
 </style>
 
-<title>モノのウェブ(WoT)モノの記述</title>
+<title>Web of Things (WoT) Thing Description</title>
 
 <style id="respec-mainstyle">
   /*****************************************************************
@@ -641,7 +647,7 @@
 
 </style>
 
-<meta name="description" content="このドキュメントでは、モノのウェブ(WoT;Web of Things)モノの記述(Thing Description)の形式モデルと共通表現について記述しています。モノの記述では、モノのメタデータとインターフェースを記述します。このとき、モノとは、モノのウェブに対して対話を提供し、モノのウェブに加えられる、物理的または仮想的なエンティティーを抽象化したものです。モノの記述は、様々なデバイスを統合し、様々なアプリケーションの相互運用を可能にする小さな語彙に基づく一連の対話を提供します。デフォルトでは、モノの記述はJSON形式でエンコードされ、JSON-LDの処理も可能です。後者は、機械が理解できる方法でモノに関する知識を表現するための強力な基盤を提供します。モノの記述のインスタンスは、モノ自身が提供できます。あるいは、モノに資源上の制限がある場合(例えば、メモリ空間が限られている場合)や、モノのウェブと互換性のある旧式デバイスがモノの記述で改造されている場合には外部で提供できます。">
+<meta name="description" content="このドキュメントでは、Web of Things (WoT) Thing Descriptionの形式モデルと共通表現について記述している。Thing Descriptionでは、Thingのメタデータとインターフェースを記述する。このとき、Thingとは、Web of Thingsに対して相互作用を提供し、Web of Thingsに加えられる、物理的または仮想的なエンティティーを抽象化したものである。Thing Descriptionは、様々なデバイスを統合し、様々なアプリケーションの相互運用を可能にする小さな語彙に基づく一連の相互作用を提供する。デフォルトでは、Thing DescriptionはJSON形式でエンコードされ、JSON-LDの処理も可能である。後者は、機械が理解できる方法でThingに関する知識を表現するための強力な基盤を提供する。Thing Descriptionのインスタンスは、Thing自身が提供できる。あるいは、Thingに資源上の制限がある場合(例えば、メモリ空間が限られている場合)や、Web of Thingsと互換性のある旧式デバイスがThing Descriptionで改造されている場合には外部で提供できる。">
 
 <link rel="canonical" href="https://www.w3.org/TR/wot-thing-description/">
 
@@ -1024,7 +1030,7 @@
 
 <div class="head"><a class="logo" href="https://www.w3.org/"><img alt="W3C" width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"></a>
 
-<h1 id="title" class="title">モノのウェブ(WoT)モノの記述</h1>
+<h1 id="title" class="title"><span class="mark">Web of Things (WoT) Thing Description</span></h1>
 
 <h2>W3C勧告 <time class="dt-published" datetime="2020-04-09">2020年4月9日</time></h2>
 
@@ -1057,9 +1063,9 @@
   <dd><a href="https://github.com/w3c/wot-thing-description/issues">File a bug</a></dd>
 </dl>
 
-<p>公開以後に報告されたエラーや問題がないか<a href="https://w3c.github.io/wot-thing-description/errata.html"><strong>正誤表</strong></a>を確認してください</p>
+<p>公開以後に報告されたエラーや問題がないか<a href="https://w3c.github.io/wot-thing-description/errata.html"><strong>正誤表</strong></a>を確認していただきたい。</p>
 
-<p><a href="http://www.w3.org/2003/03/Translations/byTechnology?technology=wot-thing-description"><strong>翻訳版</strong></a>も参照してください。</p>
+<p><a href="http://www.w3.org/2003/03/Translations/byTechnology?technology=wot-thing-description"><strong>翻訳版</strong></a>も参照していただきたい。</p>
 
 <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &#xa9; 2017-2020 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&#xae;</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.</p>
 
@@ -1070,26 +1076,26 @@
 
 <h2>要約</h2>
 
-<p>このドキュメントでは、モノのウェブ(WoT;Web of Things)モノの記述(Thing Description)の形式モデルと共通表現について記述しています。モノの記述では、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のメタデータとインターフェースを記述します。このとき、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>とは、モノのウェブに対して対話を提供し、モノのウェブに加えられる、物理的または仮想的なエンティティーを抽象化したものです。モノの記述は、様々なデバイスを統合し、様々なアプリケーションの相互運用を可能にする小さな語彙に基づく一連の対話を提供します。デフォルトでは、モノの記述はJSON形式でエンコードされ、JSON-LDの処理も可能です。後者は、機械が理解できる方法で<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>に関する知識を表現するための強力な基盤を提供します。モノの記述のインスタンスは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>自身が提供できます。あるいは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>に資源上の制限がある場合(例えば、メモリ空間が限られている場合)や、モノのウェブと互換性のある旧式デバイスがモノの記述で改造されている場合には外部で提供できます。</p>
+<p>このドキュメントでは、<span class="mark">Web of Things (WoT) Thing Description</span>の形式モデルと共通表現について記述している。<span class="mark">Thing Description</span>では、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のメタデータとインターフェースを記述する。このとき、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>とは、<span class="mark">Web of Things</span>に対して相互作用を提供し、<span class="mark">Web of Things</span>に加えられる、物理的または仮想的なエンティティーを抽象化したものである。<span class="mark">Thing Description</span>は、様々なデバイスを統合し、様々なアプリケーションの相互運用を可能にする小さな語彙に基づく一連の相互作用を提供する。デフォルトでは、<span class="mark">Thing Description</span>はJSON形式でエンコードされ、JSON-LDの処理も可能である。後者は、機械が理解できる方法で<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>に関する知識を表現するための強力な基盤を提供する。<span class="mark">Thing Description</span>のインスタンスは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>自身が提供できる。あるいは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>に資源上の制限がある場合(例えば、メモリ空間が限られている場合)や、<span class="mark">Web of Things</span>と互換性のある旧式デバイスが<span class="mark">Thing Description</span>で改造されている場合には外部で提供できる。</p>
 
 </section>
 <section id="sotd" class="introductory">
 
 <h2>このドキュメントのステータス</h2>
 
-<p><em>この項は、このドキュメントの公開時のステータスについて記述しています。他のドキュメントがこのドキュメントに取って代わることがありえます。現行の<abbr title="World Wide Web Consortium">W3C</abbr>の刊行物およびこの技術報告の最新の改訂版のリストは、https://www.w3.org/TR/の<a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr>技術報告インデックス</a>にあります。</em></p>
+<p><em>この項は、このドキュメントの公開時のステータスについて記述している。他のドキュメントがこのドキュメントに取って代わることがありえる。現行の<abbr title="World Wide Web Consortium">W3C</abbr>の刊行物およびこの技術報告の最新の改訂版のリストは、https://www.w3.org/TR/の<a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr>技術報告インデックス</a>にある。</em></p>
 
-<p>このドキュメントは、<a href="https://www.w3.org/WoT/WG/">Web of Thingsワーキンググループ</a>によって勧告として公開されました。</p>
+<p>このドキュメントは、<a href="https://www.w3.org/WoT/WG/">Web of Thingsワーキンググループ</a>によって勧告として公開された。</p>
 
-<p>この仕様の議論には<a href="https://github.com/w3c/wot-thing-description/issues">GitHubの課題</a>をお勧めします。または、メーリング・リストにコメントを送信することもできます。コメントは<a href="mailto:public-wot-wg@w3.org">public-wot-wg@w3.org</a>(<a href="https://lists.w3.org/Archives/Public/public-wot-wg/">アーカイブ</a>)に送信してください。</p>
+<p>この仕様の議論には<a href="https://github.com/w3c/wot-thing-description/issues">GitHubの課題</a>をお勧めする。または、メーリングリストにコメントを送信することもできる。コメントは<a href="mailto:public-wot-wg@w3.org">public-wot-wg@w3.org</a>(<a href="https://lists.w3.org/Archives/Public/public-wot-wg/">アーカイブ</a>)に送信していただきたい。</p>
 
-<p>ワーキンググループの<a href="https://w3c.github.io/wot-thing-description/testing/report.html">実装報告書</a>を参照してください。</p>
+<p>ワーキンググループの<a href="https://w3c.github.io/wot-thing-description/testing/report.html">実装報告書</a>を参照していただきたい。</p>
 
-<p>このドキュメントは、<abbr title="World Wide Web Consortium">W3C</abbr>メンバー、ソフトウェア開発者、他の<abbr title="World Wide Web Consortium">W3C</abbr>グループ、および他の利害関係者によりレビューされ、<abbr title="World Wide Web Consortium">W3C</abbr>勧告として管理者の協賛を得ました。これは確定済みドキュメントであり、参考資料として用いたり、別のドキュメントで引用することができます。勧告の作成における<abbr title="World Wide Web Consortium">W3C</abbr>の役割は、仕様に注意を引き付け、広範囲な開発を促進することです。これによってウェブの機能性および相互運用性が増強されます。</p>
+<p>このドキュメントは、<abbr title="World Wide Web Consortium">W3C</abbr>メンバー、ソフトウェア開発者、他の<abbr title="World Wide Web Consortium">W3C</abbr>グループ、および他の利害関係者によりレビューされ、<abbr title="World Wide Web Consortium">W3C</abbr>勧告として管理者の協賛を得た。これは確定済みドキュメントであり、参考資料として用いたり、別のドキュメントで引用することができる。勧告の作成における<abbr title="World Wide Web Consortium">W3C</abbr>の役割は、仕様に注意を引き付け、広範囲な開発を促進することである。これによってウェブの機能性および相互運用性が増強される。</p>
 
-<p>このドキュメントは、<a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr>特許方針</a>の下で活動しているグループによって作成されました。<abbr title="World Wide Web Consortium">W3C</abbr>は、このグループの成果物に関連する<a rel="disclosure" href="https://www.w3.org/2004/01/pp-impl/95969/status">あらゆる特許の開示の公開リスト</a>を維持し、このページには特許の開示に関する指示も含まれています。<a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">不可欠な請求権</a>(Essential Claim(s))を含んでいると思われる特許に関して実際に知っている人は、<a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure"><abbr title="World Wide Web Consortium">W3C</abbr>特許方針の6項</a>に従って情報を開示しなければなりません。</p>
+<p>このドキュメントは、<a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr>特許方針</a>の下で活動しているグループによって作成された。<abbr title="World Wide Web Consortium">W3C</abbr>は、このグループの成果物に関連する<a rel="disclosure" href="https://www.w3.org/2004/01/pp-impl/95969/status">あらゆる特許の開示の公開リスト</a>を維持し、このページには特許の開示に関する指示も含まれている。<a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">不可欠な請求権</a>(Essential Claim(s))を含んでいると思われる特許に関して実際に知っている人は、<a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure"><abbr title="World Wide Web Consortium">W3C</abbr>特許方針の6項</a>に従って情報を開示しなければならない。</p>
 
-<p>このドキュメントは、<a id="w3c_process_revision" href="https://www.w3.org/2019/Process-20190301/">2019年3月1日の<abbr title="World Wide Web Consortium">W3C</abbr>プロセス・ドキュメント</a>によって管理されています。</p>
+<p>このドキュメントは、<a id="w3c_process_revision" href="https://www.w3.org/2019/Process-20190301/">2019年3月1日の<abbr title="World Wide Web Consortium">W3C</abbr>プロセスドキュメント</a>によって管理されている。</p>
 
 </section>
 <nav id="toc">
@@ -1109,37 +1115,37 @@
     <ol class="toc">
       <li class="tocline"><a class="tocxref" href="#sec-core-vocabulary-definition"><bdi class="secno">5.3.1</bdi> コア語彙の定義</a>
       <ol class="toc">
-        <li class="tocline"><a class="tocxref" href="#thing"><bdi class="secno">5.3.1.1</bdi> <code>Thing</code>(モノ)</a></li>
-        <li class="tocline"><a class="tocxref" href="#interactionaffordance"><bdi class="secno">5.3.1.2</bdi> <code>InteractionAffordance</code>(対話アフォーダンス)</a></li>
-        <li class="tocline"><a class="tocxref" href="#propertyaffordance"><bdi class="secno">5.3.1.3</bdi> <code>PropertyAffordance</code>(プロパティー・アフォーダンス)</a></li>
-        <li class="tocline"><a class="tocxref" href="#actionaffordance"><bdi class="secno">5.3.1.4</bdi> <code>ActionAffordance</code>(アクション・アフォーダンス)</a></li>
-        <li class="tocline"><a class="tocxref" href="#eventaffordance"><bdi class="secno">5.3.1.5</bdi><code>EventAffordance</code>(イベント・アフォーダンス)</a></li>
+        <li class="tocline"><a class="tocxref" href="#thing"><bdi class="secno">5.3.1.1</bdi> <code>Thing</code></a></li>
+        <li class="tocline"><a class="tocxref" href="#interactionaffordance"><bdi class="secno">5.3.1.2</bdi> <code>InteractionAffordance</code>(<span class="mark">相互作用のアフォーダンス</span>)</a></li>
+        <li class="tocline"><a class="tocxref" href="#propertyaffordance"><bdi class="secno">5.3.1.3</bdi> <code>PropertyAffordance</code>(<span class="mark">Propertyの</span>アフォーダンス)</a></li>
+        <li class="tocline"><a class="tocxref" href="#actionaffordance"><bdi class="secno">5.3.1.4</bdi> <code>ActionAffordance</code>(<span class="mark">Actionの</span>アフォーダンス)</a></li>
+        <li class="tocline"><a class="tocxref" href="#eventaffordance"><bdi class="secno">5.3.1.5</bdi><code>EventAffordance</code>(<span class="mark">Eventの</span>アフォーダンス)</a></li>
         <li class="tocline"><a class="tocxref" href="#versioninfo"><bdi class="secno">5.3.1.6</bdi> <code>VersionInfo</code>(バージョン情報)</a></li>
         <li class="tocline"><a class="tocxref" href="#multilanguage"><bdi class="secno">5.3.1.7</bdi> <code>MultiLanguage</code>(多言語)</a></li>
       </ol>
       </li>
-      <li class="tocline"><a class="tocxref" href="#sec-data-schema-vocabulary-definition"><bdi class="secno">5.3.2</bdi> データ・スキーマ語彙の定義</a>
+      <li class="tocline"><a class="tocxref" href="#sec-data-schema-vocabulary-definition"><bdi class="secno">5.3.2</bdi> <span class="mark">Data Schema</span>語彙の定義</a>
       <ol class="toc">
-        <li class="tocline"><a class="tocxref" href="#dataschema"><bdi class="secno">5.3.2.1</bdi> <code>DataSchema</code>(データ・スキーマ)</a></li>
+        <li class="tocline"><a class="tocxref" href="#dataschema"><bdi class="secno">5.3.2.1</bdi> <code>DataSchema</code></a></li>
         <li class="tocline"><a class="tocxref" href="#arrayschema"><bdi class="secno">5.3.2.2</bdi> <code>ArraySchema</code>(配列スキーマ)</a></li>
-        <li class="tocline"><a class="tocxref" href="#booleanschema"><bdi class="secno">5.3.2.3</bdi> <code>BooleanSchema</code>(ブール・スキーマ)</a></li>
+        <li class="tocline"><a class="tocxref" href="#booleanschema"><bdi class="secno">5.3.2.3</bdi> <code>BooleanSchema</code>(ブールスキーマ)</a></li>
         <li class="tocline"><a class="tocxref" href="#numberschema"><bdi class="secno">5.3.2.4</bdi> <code>NumberSchema</code>(数値スキーマ)</a></li>
         <li class="tocline"><a class="tocxref" href="#integerschema"><bdi class="secno">5.3.2.5</bdi> <code>IntegerSchema</code>(整数スキーマ)</a></li>
-        <li class="tocline"><a class="tocxref" href="#objectschema"><bdi class="secno">5.3.2.6</bdi> <code>ObjectSchema</code>(オブジェクト・スキーマ)</a></li>
+        <li class="tocline"><a class="tocxref" href="#objectschema"><bdi class="secno">5.3.2.6</bdi> <code>ObjectSchema</code>(オブジェクトスキーマ)</a></li>
         <li class="tocline"><a class="tocxref" href="#stringschema"><bdi class="secno">5.3.2.7</bdi> <code>StringSchema</code>(文字列スキーマ)</a></li>
         <li class="tocline"><a class="tocxref" href="#nullschema"><bdi class="secno">5.3.2.8</bdi> <code>NullSchema</code>(ヌル(Null)スキーマ)</a></li>
       </ol>
       </li>
       <li class="tocline"><a class="tocxref" href="#sec-security-vocabulary-definition"><bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義</a>
       <ol class="toc">
-        <li class="tocline"><a class="tocxref" href="#securityscheme"><bdi class="secno">5.3.3.1</bdi> <code>SecurityScheme</code>(セキュリティ・スキーム)</a></li>
-        <li class="tocline"><a class="tocxref" href="#nosecurityscheme"><bdi class="secno">5.3.3.2</bdi> <code>NoSecurityScheme</code>(セキュリティ・スキームなし)</a></li>
-        <li class="tocline"><a class="tocxref" href="#basicsecurityscheme"><bdi class="secno">5.3.3.3</bdi> <code>BasicSecurityScheme</code>(基本セキュリティ・スキーム)</a></li>
-        <li class="tocline"><a class="tocxref" href="#digestsecurityscheme"><bdi class="secno">5.3.3.4</bdi> <code>DigestSecurityScheme</code>(ダイジェスト・セキュリティ・スキーム)</a></li>
-        <li class="tocline"><a class="tocxref" href="#apikeysecurityscheme"><bdi class="secno">5.3.3.5</bdi> <code>APIKeySecurityScheme</code>(APIキー・セキュリティ・スキーム)</a></li>
-        <li class="tocline"><a class="tocxref" href="#bearersecurityscheme"><bdi class="secno">5.3.3.6</bdi> <code>BearerSecurityScheme</code>(ベアラー・セキュリティー・スキーム)</a></li>
-        <li class="tocline"><a class="tocxref" href="#psksecurityscheme"><bdi class="secno">5.3.3.7</bdi> <code>PSKSecurityScheme</code>(PSKセキュリティ・スキーム)</a></li>
-        <li class="tocline"><a class="tocxref" href="#oauth2securityscheme"><bdi class="secno">5.3.3.8</bdi> <code>OAuth2SecurityScheme</code>(OAuth2セキュリティ・スキーム)</a></li>
+        <li class="tocline"><a class="tocxref" href="#securityscheme"><bdi class="secno">5.3.3.1</bdi> <code>SecurityScheme</code>(セキュリティスキーム)</a></li>
+        <li class="tocline"><a class="tocxref" href="#nosecurityscheme"><bdi class="secno">5.3.3.2</bdi> <code>NoSecurityScheme</code>(セキュリティスキームなし)</a></li>
+        <li class="tocline"><a class="tocxref" href="#basicsecurityscheme"><bdi class="secno">5.3.3.3</bdi> <code>BasicSecurityScheme</code>(基本セキュリティスキーム)</a></li>
+        <li class="tocline"><a class="tocxref" href="#digestsecurityscheme"><bdi class="secno">5.3.3.4</bdi> <code>DigestSecurityScheme</code>(ダイジェストセキュリティスキーム)</a></li>
+        <li class="tocline"><a class="tocxref" href="#apikeysecurityscheme"><bdi class="secno">5.3.3.5</bdi> <code>APIKeySecurityScheme</code>(APIキーセキュリティスキーム)</a></li>
+        <li class="tocline"><a class="tocxref" href="#bearersecurityscheme"><bdi class="secno">5.3.3.6</bdi> <code>BearerSecurityScheme</code>(ベアラーセキュリティースキーム)</a></li>
+        <li class="tocline"><a class="tocxref" href="#psksecurityscheme"><bdi class="secno">5.3.3.7</bdi> <code>PSKSecurityScheme</code>(PSKセキュリティスキーム)</a></li>
+        <li class="tocline"><a class="tocxref" href="#oauth2securityscheme"><bdi class="secno">5.3.3.8</bdi> <code>OAuth2SecurityScheme</code>(OAuth2セキュリティスキーム)</a></li>
       </ol>
       </li>
       <li class="tocline"><a class="tocxref" href="#sec-hypermedia-vocabulary-definition"><bdi class="secno">5.3.4</bdi> ハイパーメディア制御語彙の定義</a>
@@ -1158,9 +1164,9 @@
   <ol class="toc">
     <li class="tocline"><a class="tocxref" href="#td-basic-types-mapping"><bdi class="secno">6.1</bdi> JSONの型へのマッピング</a></li>
     <li class="tocline"><a class="tocxref" href="#omitting-default-values"><bdi class="secno">6.2</bdi> デフォルト値の省略</a></li>
-    <li class="tocline"><a class="tocxref" href="#td-class-serialization"><bdi class="secno">6.3</bdi> 情報モデルのシリアル化</a>
+    <li class="tocline"><a class="tocxref" href="#td-class-serialization"><bdi class="secno">6.3</bdi> 情報モデルの<span class="mark">シリアライゼーション</span></a>
     <ol class="toc">
-      <li class="tocline"><a class="tocxref" href="#sec-thing-as-a-whole-json"><bdi class="secno">6.3.1</bdi> モノのルート・オブジェクト</a></li>
+      <li class="tocline"><a class="tocxref" href="#sec-thing-as-a-whole-json"><bdi class="secno">6.3.1</bdi> <span class="mark">Thing</span>のルートオブジェクト</a></li>
       <li class="tocline"><a class="tocxref" href="#titles-descriptions-serialization-json"><bdi class="secno">6.3.2</bdi> 人間が読めるメタデータ</a></li>
       <li class="tocline"><a class="tocxref" href="#version-serialization-json"><bdi class="secno">6.3.3</bdi> <code>version</code>(バージョン)</a></li>
       <li class="tocline"><a class="tocxref" href="#security-serialization-json"><bdi class="secno">6.3.4</bdi> <code>securityDefinitions</code>(セキュリティ定義)と<code>security</code>(セキュリティ)</a></li>
@@ -1169,7 +1175,7 @@
       <li class="tocline"><a class="tocxref" href="#event-serialization-json"><bdi class="secno">6.3.7</bdi> <code>events</code>(イベント)</a></li>
       <li class="tocline"><a class="tocxref" href="#link-serialization-json"><bdi class="secno">6.3.8</bdi> <code>links</code>(リンク)</a></li>
       <li class="tocline"><a class="tocxref" href="#form-serialization-json"><bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a></li>
-      <li class="tocline"><a class="tocxref" href="#data-schema-serialization-json"><bdi class="secno">6.3.10</bdi> データ・スキーマ</a></li>
+      <li class="tocline"><a class="tocxref" href="#data-schema-serialization-json"><bdi class="secno">6.3.10</bdi> <span class="mark">Data Schema</span></a></li>
     </ol>
     </li>
     <li class="tocline"><a class="tocxref" href="#identification"><bdi class="secno">6.4</bdi> 識別</a></li>
@@ -1178,18 +1184,18 @@
   <li class="tocline"><a class="tocxref" href="#sec-context-extensions"><bdi class="secno">7.</bdi> TDコンテキスト拡張</a>
   <ol class="toc">
     <li class="tocline"><a class="tocxref" href="#semantic-annotations"><bdi class="secno">7.1</bdi> セマンティックなアノテーション</a></li>
-    <li class="tocline"><a class="tocxref" href="#adding-protocol-bindings"><bdi class="secno">7.2</bdi> プロトコル・バインディングの追加</a></li>
-    <li class="tocline"><a class="tocxref" href="#adding-security-schemes"><bdi class="secno">7.3</bdi> セキュリティ・スキームの追加</a></li>
+    <li class="tocline"><a class="tocxref" href="#adding-protocol-bindings"><bdi class="secno">7.2</bdi> プロトコルバインディングの追加</a></li>
+    <li class="tocline"><a class="tocxref" href="#adding-security-schemes"><bdi class="secno">7.3</bdi> セキュリティスキームの追加</a></li>
   </ol>
   </li>
   <li class="tocline"><a class="tocxref" href="#behavior"><bdi class="secno">8.</bdi> 動作の言明</a>
   <ol class="toc">
-    <li class="tocline"><a class="tocxref" href="#behavior-security"><bdi class="secno">8.1</bdi> セキュリティの設定</a></li>
-    <li class="tocline"><a class="tocxref" href="#behavior-data"><bdi class="secno">8.2</bdi> データ・スキーマ</a></li>
-    <li class="tocline"><a class="tocxref" href="#protocol-bindings"><bdi class="secno">8.3</bdi> プロトコル・バインディング</a>
+    <li class="tocline"><a class="tocxref" href="#behavior-security"><bdi class="secno">8.1</bdi> <span class="mark">セキュリティ構成情報</span></a></li>
+    <li class="tocline"><a class="tocxref" href="#behavior-data"><bdi class="secno">8.2</bdi> <span class="mark">Data Schema</span></a></li>
+    <li class="tocline"><a class="tocxref" href="#protocol-bindings"><bdi class="secno">8.3</bdi> プロトコルバインディング</a>
     <ol class="toc">
-      <li class="tocline"><a class="tocxref" href="#http-binding-assertions"><bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコル・バインディング</a></li>
-      <li class="tocline"><a class="tocxref" href="#other-protocol-bindings"><bdi class="secno">8.3.2</bdi> その他のプロトコル・バインディング</a></li>
+      <li class="tocline"><a class="tocxref" href="#http-binding-assertions"><bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコルバインディング</a></li>
+      <li class="tocline"><a class="tocxref" href="#other-protocol-bindings"><bdi class="secno">8.3.2</bdi> その他のプロトコルバインディング</a></li>
     </ol>
     </li>
   </ol>
@@ -1202,29 +1208,29 @@
     <li class="tocline"><a class="tocxref" href="#sec-security-consideration-global-id-risk"><bdi class="secno">9.4</bdi> グローバルに一意な識別子に関するプライバシーのリスク</a></li>
     <li class="tocline"><a class="tocxref" href="#sec-security-consideration-TD-tampering"><bdi class="secno">9.5</bdi> TDの傍受と改ざんに関するセキュリティのリスク</a></li>
     <li class="tocline"><a class="tocxref" href="#sec-security-consideration-context-tampering"><bdi class="secno">9.6</bdi> コンテキストの傍受と改ざんに関するセキュリティのリスク</a></li>
-    <li class="tocline"><a class="tocxref" href="#sec-security-consideration-inferencing"><bdi class="secno">9.7</bdi> 個人を特定できる情報の推測に関するプライバシーのリスク</a></li>
+    <li class="tocline"><a class="tocxref" href="#sec-security-consideration-inferencing"><bdi class="secno">9.7</bdi> <span class="mark">個人識別可能情報</span>の推測に関するプライバシーのリスク</a></li>
   </ol>
   </li>
   <li class="tocline"><a class="tocxref" href="#iana-section"><bdi class="secno">10.</bdi> IANAに関する留意点</a>
   <ol class="toc">
-    <li class="tocline"><a class="tocxref" href="#media-type-section"><bdi class="secno">10.1</bdi> <code>application/td+json</code>メディア・タイプの登録</a></li>
+    <li class="tocline"><a class="tocxref" href="#media-type-section"><bdi class="secno">10.1</bdi> <code>application/td+json</code>メディアタイプの登録</a></li>
     <li class="tocline"><a class="tocxref" href="#content-format-section"><bdi class="secno">10.2</bdi> CoAPコンテンツ形式の登録</a></li>
   </ol>
   </li>
-  <li class="tocline"><a class="tocxref" href="#example-serialization"><bdi class="secno">A.</bdi> モノの記述のインスタンスの例</a>
+  <li class="tocline"><a class="tocxref" href="#example-serialization"><bdi class="secno">A.</bdi> <span class="mark">Thing Description</span>のインスタンスの例</a>
   <ol class="toc">
-    <li class="tocline"><a class="tocxref" href="#myLampThing-example-serialization"><bdi class="secno">A.1</bdi> CoAPプロトコル・バインディングを用いたMyLampThingの例</a></li>
-    <li class="tocline"><a class="tocxref" href="#myLightSensor-example-serialization"><bdi class="secno">A.2</bdi> MQTTプロトコル・バインディングを用いたMyIlluminanceSensorの例</a></li>
-    <li class="tocline"><a class="tocxref" href="#webhook-example-serialization"><bdi class="secno">A.3</bdi> Webhookイベントの例</a></li>
+    <li class="tocline"><a class="tocxref" href="#myLampThing-example-serialization"><bdi class="secno">A.1</bdi> CoAPプロトコルバインディングを用いたMyLampThingの例</a></li>
+    <li class="tocline"><a class="tocxref" href="#myLightSensor-example-serialization"><bdi class="secno">A.2</bdi> MQTTプロトコルバインディングを用いたMyIlluminanceSensorの例</a></li>
+    <li class="tocline"><a class="tocxref" href="#webhook-example-serialization"><bdi class="secno">A.3</bdi> Webhook <span class="mark">Event</span>の例</a></li>
   </ol>
   </li>
   <li class="tocline"><a class="tocxref" href="#json-schema-for-validation"><bdi class="secno">B.</bdi> TDインスタンス検証用JSONスキーマ</a></li>
-  <li class="tocline"><a class="tocxref" href="#thing-templates"><bdi class="secno">C.</bdi> モノの記述テンプレート</a>
+  <li class="tocline"><a class="tocxref" href="#thing-templates"><bdi class="secno">C.</bdi> <span class="mark">Thing Description</span>テンプレート</a>
   <ol class="toc">
-    <li class="tocline"><a class="tocxref" href="#thing-template-examples"><bdi class="secno">C.1</bdi> モノの記述テンプレートの例</a>
+    <li class="tocline"><a class="tocxref" href="#thing-template-examples"><bdi class="secno">C.1</bdi> <span class="mark">Thing Description</span>テンプレートの例</a>
     <ol class="toc">
-      <li class="tocline"><a class="tocxref" href="#lamp-thing-template"><bdi class="secno">C.1.1</bdi> モノの記述テンプレート: 照明</a></li>
-      <li class="tocline"><a class="tocxref" href="#buzzer-thing-template"><bdi class="secno">C.1.2</bdi> モノの記述テンプレート: ブザー</a></li>
+      <li class="tocline"><a class="tocxref" href="#lamp-thing-template"><bdi class="secno">C.1.1</bdi> <span class="mark">Thing Description</span>テンプレート: 照明</a></li>
+      <li class="tocline"><a class="tocxref" href="#buzzer-thing-template"><bdi class="secno">C.1.2</bdi> <span class="mark">Thing Description</span>テンプレート: ブザー</a></li>
     </ol>
     </li>
   </ol>
@@ -1252,18 +1258,18 @@
 
 <h2 id="x1-introduction"><bdi class="secno">1.</bdi> はじめに<a class="self-link" aria-label="§" href="#introduction"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
-<p>WoTモノの記述(TD)は、<abbr title="World Wide Web Consortium">W3C</abbr>のモノのウェブ(WoT)の中心的な構成要素であり、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のエントリ・ポイントと考えることができます(ウェブサイトの<i>index.html</i>とよく似ています)。TDのインスタンスには4つの主要コンポーネントがあります。それらは、<a href="#thing">モノ</a>自身に関するテキスト形式のメタデータ、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の使用方法を示す一連の<a href="#interactionaffordance">対話アフォーダンス</a>、機械による理解のために<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と交換されるデータの<a href="#sec-data-schema-vocabulary-definition">スキーマ</a>、そして最後に、ウェブ上の他の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>やドキュメントとの形式的または非形式的な関係を表すための<a href="#sec-hypermedia-vocabulary-definition">ウェブ・リンク</a>です。</p>
+<p><span class="mark">WoT Thing Description (TD)</span>は、<abbr title="World Wide Web Consortium">W3C</abbr>の<span class="mark">Web of Things (WoT)</span>の中心的な構成要素であり、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のエントリポイントと考えることができる(ウェブサイトの<i>index.html</i>とよく似ている)。TDのインスタンスには4つの主要コンポーネントがある。それらは、<a href="#thing"><span class="mark">Thing</span></a>自身に関するテキスト形式のメタデータ、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の使用方法を示す一連の<a href="#interactionaffordance"><span class="mark">相互作用のアフォーダンス</span></a>、機械による理解のために<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と交換されるデータの<a href="#sec-data-schema-vocabulary-definition">スキーマ</a>、そして最後に、ウェブ上の他の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>やドキュメントとの形式的または非形式的な関係を表すための<a href="#sec-hypermedia-vocabulary-definition">ウェブリンク</a>である。</p>
 
-<p><abbr title="World Wide Web Consortium">W3C</abbr> WoTの<a href="#dfn-interaction-model" class="internalDFN" data-link-type="dfn">対話モデル</a>では、3種類の<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>を定義しています。プロパティー(<a href="#propertyaffordance"><code>PropertyAffordance</code></a>クラス)は、現在の値の取得や操作状態の設定などのパラメータの検知と制御に使用できます。アクション(<a href="#actionaffordance"><code>ActionAffordance</code></a>クラス)は、物理的な(したがって、時間のかかる)プロセスの呼び出しをモデル化しますが、既存のプラットフォームのRPCのような呼び出しを抽象化するためにも使用できます。イベント(<a href="#eventaffordance"><code>EventAffordance</code></a>クラス)は、通知、個別のイベント、または値のストリームが受信者に非同期で送信される通信のプッシュ・モデルに用いられます。詳細に関しては、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]を参照してください。</p>
+<p><abbr title="World Wide Web Consortium">W3C</abbr> WoTの<a href="#dfn-interaction-model" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用モデル</span></a>では、3種類の<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>を定義している。<span class="mark">Property</span>(<a href="#propertyaffordance"><code>PropertyAffordance</code></a>クラス)は、現在の値の取得や操作状態の設定などのパラメータの検知と制御に使用できる。<span class="mark">Action</span>(<a href="#actionaffordance"><code>ActionAffordance</code></a>クラス)は、物理的な(したがって、時間のかかる)プロセスの呼び出しをモデル化するが、既存のプラットフォームのRPCのような呼び出しを抽象化するためにも使用できる。<span class="mark">Event</span>(<a href="#eventaffordance"><code>EventAffordance</code></a>クラス)は、通知、個別の<span class="mark">出来事</span>、または値のストリームが受信者に非同期で送信される通信のプッシュモデルに用いられる。詳細に関しては、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]を参照していただきたい。</p>
 
-<p>一般的に、TDは、URIスキーム[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>](例えば、<code>http</code>、<code>coap</code>など。[<cite><a class="bibref" data-link-type="biblio" href="#bib-iana-uri-schemes" title="Uniform Resource Identifier (URI) Schemes">IANA-URI-SCHEMES</a></cite>])で識別される様々な<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>に関するメタデータ、メディア・タイプ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]に基づくコンテンツ・タイプ(例えば、<code>application/json</code>、<code>application/xml</code>、<code>application/cbor</code>、<code>application/exi</code>など。[<cite><a class="bibref" data-link-type="biblio" href="#bib-iana-media-types" title="Media Types">IANA-MEDIA-TYPES</a></cite>])、およびセキュリティのメカニズム(認証、許可、機密性など)を提供します。TDのインスタンスのシリアル化は、JSON[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8259" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC8259</a></cite>]に基づいており、JSON名は、この仕様書で定義しているTD語彙の用語を指します。さらに、TDのJSONシリアル化は、JSON-LD 1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>]の構文に従い、拡張機能と豊かなセマンティックの処理を可能にします。</p>
+<p>一般的に、TDは、URIスキーム[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>](例えば、<code>http</code>、<code>coap</code>など。[<cite><a class="bibref" data-link-type="biblio" href="#bib-iana-uri-schemes" title="Uniform Resource Identifier (URI) Schemes">IANA-URI-SCHEMES</a></cite>])で識別される様々な<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>に関するメタデータ、メディアタイプ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]に基づくコンテンツタイプ(例えば、<code>application/json</code>、<code>application/xml</code>、<code>application/cbor</code>、<code>application/exi</code>など。[<cite><a class="bibref" data-link-type="biblio" href="#bib-iana-media-types" title="Media Types">IANA-MEDIA-TYPES</a></cite>])、およびセキュリティのメカニズム(認証、<span class="mark">認可</span>、機密性など)を提供する。TDのインスタンスの<span class="mark">シリアライゼーション</span>は、JSON[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8259" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC8259</a></cite>]に基づいており、JSON名は、この仕様書で定義しているTD 語彙の用語を指す。さらに、TDのJSON<span class="mark">シリアライゼーション</span>は、JSON-LD 1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>]の構文に従い、拡張機能と豊かなセマンティックの処理を可能にする。</p>
 
-<p><a href="#simple-thing-description-sample">例1</a>は、TDのインスタンスです。<i>MyLampThing</i>というタイトルの照明である<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>を記述することにより、プロパティー、アクション、イベントの<a href="#dfn-interaction-model" class="internalDFN" data-link-type="dfn">対話モデル</a>を示しています。</p>
+<p><a href="#simple-thing-description-sample">例1</a>は、TDのインスタンスである。<i>MyLampThing</i>というタイトルの照明である<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>を記述することにより、<span class="mark">Property</span>、<span class="mark">Action</span>、<span class="mark">Event</span>の<a href="#dfn-interaction-model" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用モデル</span></a>を示している。</p>
 
 <aside class="example" id="simple-thing-description-sample">
-<div class="marker"><a class="self-link" href="#simple-thing-description-sample">例<bdi>1</bdi></a><span class="example-title">: モノの記述のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#simple-thing-description-sample">例<bdi>1</bdi></a><span class="example-title">: <span class="mark">Thing Description</span>のサンプル</span></div>
 
 <pre aria-busy="false"><code class="hljs json">{
     <span class="hljs-attr">"@context"</span>: <span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>,
@@ -1296,18 +1302,18 @@
 }</code></pre>
 </aside>
 
-<p>このTDの例から、タイトルの<i>状態</i>を持つ1つの<a href="#propertyaffordance">プロパティー・アフォーダンス</a>が存在することが分かります。さらに、(<code>forms</code> 構造内で<code>href</code>のメンバーによってアナウンスされる)<code>https://mylamp.example.com/status</code>というURIでGETメソッドを用いて(セキュアな形式の)HTTPプロトコルを介してこのプロパティーにアクセスでき、文字列ベースの状態の値を返すということを示す情報が提供されています。GETメソッドの使用については明示的に述べられていませんが、それは、このドキュメントで定義しているデフォルト時の解釈(default assumption)の1つです。</p>
+<p>このTDの例から、タイトルの<i>状態</i>を持つ1つの<a href="#propertyaffordance"><span class="mark">Propertyの</span>アフォーダンス</a>が存在することが分かる。さらに、(<code>forms</code> 構造内で<code>href</code>のメンバーによってアナウンスされる)<code>https://mylamp.example.com/status</code>というURIでGETメソッドを用いて(セキュアな形式の)HTTPプロトコルを介してこの<span class="mark">Property</span>にアクセスでき、文字列ベースの状態の値を返すということを示す情報が提供されている。GETメソッドの使用については明示的に述べられていないが、それは、このドキュメントで定義しているデフォルト時の解釈(default assumption)の1つである。</p>
 
-<p>同様に、<code>https://mylamp.example.com/toggle</code>という資源でPOSTメソッドを用いてスイッチの状態を切り替える<a href="#actionaffordance">アクション・アフォーダンス</a>が指定されており、この場合も、POSTはアクションを呼び出すためのデフォルト時の解釈です。</p>
+<p>同様に、<code>https://mylamp.example.com/toggle</code>という資源でPOSTメソッドを用いてスイッチの状態を切り替える<a href="#actionaffordance"><span class="mark">Actionの</span>アフォーダンス</a>が指定されており、この場合も、POSTは<span class="mark">Action</span>を呼び出すためのデフォルト時の解釈である。</p>
 
-<p><a href="#eventaffordance">イベント・アフォーダンス</a>により、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が非同期メッセージを送信するメカニズムが有効になります。ここでは、<code>https://mylamp.example.com/oh</code>のロング・ポーリングのサブプロトコル(long polling subprotocol)でHTTPを用いて、照明が過熱するイベントの可能性があるときに通知される購読を取得できます。</p>
+<p><a href="#eventaffordance"><span class="mark">Eventの</span>アフォーダンス</a>により、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が非同期メッセージを送信するメカニズムが有効になる。ここでは、<code>https://mylamp.example.com/oh</code>のロングポーリングのサブプロトコル(long polling subprotocol)でHTTPを用いて、照明が過熱する<span class="mark">出来事</span>の可能性があるときに通知される<span class="mark">登録</span>を取得できる。</p>
 
-<p>この例では、アクセスにユーザ名とパスワードを求める<code>basic</code>なセキュリティ・スキームも指定しています。セキュリティ・スキームは、まず<code>securityDefinitions</code>で名前が与えられ、次に<code>security</code>の部分でその名前を指定することでアクティブ化されることに注意してください。この例では、HTTPプロトコルの使用と組み合わせて、HTTP基本認証の使用方法を示しています。少なくとも1つのセキュリティ・スキームを最上位レベルで指定することは必須であり、それが、すべての資源に対するデフォルトのアクセス要件となります。しかし、セキュリティ・スキームはフォームごとに指定することもできます。フォームのレベルで指定した設定は、<code>Thing</code>レベルで指定した設定を上書きするため、きめ細かいアクセス制御の指定が可能です。<code>nosec</code>という特殊なセキュリティ・スキームを用いて、アクセス制御メカニズムが用いられていないことを示すこともできます。後ほど、追加の例を示します。</p>
+<p>この例では、アクセスにユーザ名とパスワードを求める<code>basic</code>なセキュリティスキームも指定している。セキュリティスキームは、まず<code>securityDefinitions</code>で名前が与えられ、次に<code>security</code>の部分でその名前を指定することでアクティブ化されることに注意していただきたい。この例では、HTTPプロトコルの使用と組み合わせて、HTTP基本認証の使用方法を示している。少なくとも1つのセキュリティスキームを最上位レベルで指定することは必須であり、それが、すべての資源に対するデフォルトのアクセス要件となる。しかし、セキュリティスキームはフォームごとに指定することもできる。フォームのレベルで指定した<span class="mark">構成</span>は、<code>Thing</code>レベルで指定した<span class="mark">構成</span>を上書きするため、きめ細かいアクセス制御の指定が可能である。<code>nosec</code>という特殊なセキュリティスキームを用いて、アクセス制御メカニズムが用いられていないことを示すこともできる。後ほど、追加の例を示す。</p>
 
-<p>モノの記述は、名前空間にコンテキストの定義を追加する可能性を提供します。特定のアプリケーション領域の論理規則などの正式な知識が特定の名前空間にある場合は、このメカニズムを用いて、モノの記述のインスタンスの内容に追加のセマンティクスを組み込むことができます。コンテキスト情報は、<code>forms</code>フィールドで宣言されている基礎となる通信プロトコルの一部の設定と動作を指定するのにも役立ちます。<a href="#thing-description-full-serialization">例2</a>では、<code>@context</code>に2番目の定義を導入して、<a href="https://w3id.org/saref">SAREF</a>(Smart Appliance Reference Ontology)[<cite><a class="bibref" data-link-type="biblio" href="#bib-smartm2m" title="ETSI TS 103 264 V2.1.1 (2017-03): SmartM2M; Smart Appliances; Reference Ontology and oneM2M Mapping">SMARTM2M</a></cite>]への参照として接頭辞<code>saref</code>を宣言することにより、例1のTDサンプルを拡張しています。このIoTオントロジーには、<code>@type</code>フィールドの値として設定できるセマンティック・ラベルとして解釈される用語が含まれており、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のセマンティクスとその<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>を提供します。下記の例では、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は<code>saref:LightSwitch</code>、<code>status</code><a href="#dfn-property" class="internalDFN" data-link-type="dfn">プロパティー</a>は<code>saref:OnOffState</code>、<code>toggle</code><a href="#dfn-action" class="internalDFN" data-link-type="dfn">アクション</a>は<code>saref:ToggleCommand</code>でラベル付けしています。</p>
+<p><span class="mark">Thing Description</span>は、名前空間にコンテキストの定義を追加する可能性を提供する。特定のアプリケーション領域の論理規則などの正式な知識が特定の名前空間にある場合は、このメカニズムを用いて、<span class="mark">Thing Description</span>のインスタンスの内容に追加のセマンティクスを組み込むことができる。コンテキスト情報は、<code>forms</code>フィールドで宣言されている基礎となる通信プロトコルの一部の<span class="mark">構成</span>と動作を指定するのにも役立つ。<a href="#thing-description-full-serialization">例2</a>では、<code>@context</code>に2番目の定義を導入して、<a href="https://w3id.org/saref">SAREF</a>(Smart Appliance Reference Ontology)[<cite><a class="bibref" data-link-type="biblio" href="#bib-smartm2m" title="ETSI TS 103 264 V2.1.1 (2017-03): SmartM2M; Smart Appliances; Reference Ontology and oneM2M Mapping">SMARTM2M</a></cite>]への参照として接頭辞<code>saref</code>を宣言することにより、例1のTDサンプルを拡張している。このIoTオントロジーには、<code>@type</code>フィールドの値として設定できるセマンティックラベルとして解釈される用語が含まれており、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のセマンティクスとその<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>を提供する。下記の例では、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は<code>saref:LightSwitch</code>、<code>status</code> <a href="#dfn-property" class="internalDFN" data-link-type="dfn"><span class="mark">Property</span></a>は<code>saref:OnOffState</code>、<code>toggle</code> <a href="#dfn-action" class="internalDFN" data-link-type="dfn">Action</a>は<code>saref:ToggleCommand</code>でラベル付けしている。</p>
 
 <aside class="example" id="thing-description-full-serialization">
-<div class="marker"><a class="self-link" href="#thing-description-full-serialization">例<bdi>2</bdi></a><span class="example-title">: セマンティック・アノテーション用のTDコンテキスト拡張を用いたモノの記述</span></div>
+<div class="marker"><a class="self-link" href="#thing-description-full-serialization">例<bdi>2</bdi></a><span class="example-title">: セマンティックアノテーション用のTDコンテキスト拡張を用いた<span class="mark">Thing Description</span></span></div>
 
 <pre aria-busy="false"><code class="hljs json">{
     <span class="hljs-attr">"@context"</span>: [
@@ -1350,61 +1356,61 @@
 }</code></pre>
 </aside>
 
-<p>一部の<code>@context</code>内の宣言メカニズムは、JSON-LDで指定されます。TDのインスタンスは、その仕様のバージョン1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]に準拠しています。したがって、TDのインスタンスはRDFドキュメントとして処理することもできます(セマンティックな処理の詳細に関しては、付録<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> SON-LDコンテキストの使用法</a>や<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下のドキュメントを参照)。</p>
+<p>一部の<code>@context</code>内の宣言メカニズムは、JSON-LDで指定される。TDのインスタンスは、その仕様のバージョン1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]に準拠している。したがって、TDのインスタンスはRDFドキュメントとして処理することもできる(セマンティックな処理の詳細に関しては、付録<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> SON-LDコンテキストの使用法</a>や<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下のドキュメントを参照)。</p>
 
 </section>
 <section id="conformance">
 
 <h2 id="x2-conformance"><bdi class="secno">2.</bdi> 適合性<a class="self-link" aria-label="§" href="#conformance"></a></h2>
 
-<p>非規範的と記している項と同じく、この仕様のすべての作成ガイドライン、図、例、注は、非規範的です。この仕様のその他の部分はすべて規範的です。</p>
+<p>非規範的と記している項と同じく、この仕様のすべての作成ガイドライン、図、例、注は、非規範的である。この仕様のその他の部分はすべて規範的である。</p>
 
-<p>このドキュメントの「することができる／してもよい(<em class="rfc2119">MAY</em>)」、「しなければならない(<em class="rfc2119">MUST</em>)」、「してはならない(<em class="rfc2119">MUST NOT</em>)」、「推奨される(<em class="rfc2119">RECOMMENDED</em>)」、「すべきである／する必要がある(<em class="rfc2119">SHOULD</em>)」、「すべきでない／する必要がない(<em class="rfc2119">SHOULD NOT</em>)」というキーワードは、ここで示しているように、すべて大文字で表示されている場合にのみ、<a href="https://tools.ietf.org/html/bcp14">BCP 14</a>[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]で記述されているように解釈されるべきです。</p>
+<p>このドキュメントの「することができる／してもよい(<em class="rfc2119">MAY</em>)」、「しなければならない(<em class="rfc2119">MUST</em>)」、「してはならない(<em class="rfc2119">MUST NOT</em>)」、「推奨される(<em class="rfc2119">RECOMMENDED</em>)」、「すべきである／する必要がある(<em class="rfc2119">SHOULD</em>)」、「すべきでない／する必要がない(<em class="rfc2119">SHOULD NOT</em>)」というキーワードは、ここで示しているように、すべて大文字で表示されている場合にのみ、<a href="https://tools.ietf.org/html/bcp14">BCP 14</a>[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]で記述されているように解釈されるべきである。</p>
 
-<p>モノの記述のインスタンスは、モノの記述のシリアル化に関する<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>と<a href="#sec-td-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.</bdi> TD表現形式</a>の規範的なステートメントに従っていれば、この仕様に準拠します。</p>
+<p><span class="mark">Thing Description</span>のインスタンスは、<span class="mark">Thing Description</span>の<span class="mark">シリアライゼーション</span>に関する<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>と<a href="#sec-td-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.</bdi> TD表現形式</a>の規範的なステートメントに従っていれば、この仕様に準拠する。</p>
 
-<p>モノの記述のインスタンスを検証するためのJSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]は、付録<a href="#json-schema-for-validation" class="sec-ref">§&nbsp;<bdi class="secno">B.</bdi> TDのインスタンス検証用JSONスキーマ</a>で提供しています。</p>
+<p><span class="mark">Thing Description</span>のインスタンスを検証するためのJSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]は、付録<a href="#json-schema-for-validation" class="sec-ref">§&nbsp;<bdi class="secno">B.</bdi> TDのインスタンス検証用JSONスキーマ</a>で提供している。</p>
 
 </section>
 <section id="terminology" class="informative">
 
 <h2 id="x3-terminology"><bdi class="secno">3.</bdi> 用語<a class="self-link" aria-label="§" href="#terminology"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
-<p><dfn data-dfn-type="dfn" data-plurals="things" id="dfn-thing">モノ</dfn>(Thing)、<dfn data-dfn-type="dfn" data-plurals="consumers" id="dfn-consumer">利用者</dfn>(Consumer)、<dfn data-dfn-type="dfn" data-plurals="thing descriptions" id="dfn-thing-description">モノの記述</dfn>(Thing Description)(<dfn data-dfn-type="dfn" id="dfn-td">TD</dfn>)、<dfn data-dfn-type="dfn" id="dfn-interaction-model">対話モデル</dfn>(Interaction Model)、<dfn data-dfn-type="dfn" data-plurals="interaction affordances" id="dfn-interaction-affordance">対話アフォーダンス</dfn>(Interaction Affordance)、<dfn data-dfn-type="dfn" data-plurals="properties" id="dfn-property">プロパティー</dfn>(Property)、<dfn data-dfn-type="dfn" data-plurals="actions" id="dfn-action">アクション</dfn>(Action)、<dfn data-dfn-type="dfn" data-plurals="events" id="dfn-event">イベント</dfn>(Event)、<dfn data-dfn-type="dfn" data-plurals="protocol bindings" id="dfn-protocol-binding">プロトコル・バインディング</dfn>(Protocol Binding)、<dfn data-dfn-type="dfn" data-plurals="servients" id="dfn-servient">サービエント</dfn>(Servient)、<dfn data-dfn-type="dfn" id="dfn-wot-interface">WoTインターフェース</dfn>(WoT Interface)、<dfn data-dfn-type="dfn" id="dfn-wot-runtime">WoTランタイム</dfn>(WoT Runtime)などの基本的なWoT用語は、WoTアーキテクチャ仕様[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]の<a href="https://www.w3.org/TR/wot-architecture/#terminology">3項</a>で定義しています。</p>
+<p><dfn data-dfn-type="dfn" data-plurals="things" id="dfn-thing"><span class="mark">Thing</span></dfn>、<dfn data-dfn-type="dfn" data-plurals="consumers" id="dfn-consumer"><span class="mark">Consumer</span></dfn>、<dfn data-dfn-type="dfn" data-plurals="thing descriptions" id="dfn-thing-description"><span class="mark">Thing Description</span></dfn> (<dfn data-dfn-type="dfn" id="dfn-td">TD</dfn>)、<dfn data-dfn-type="dfn" id="dfn-interaction-model"><span class="mark">相互作用モデル</span></dfn>(Interaction Model)、<dfn data-dfn-type="dfn" data-plurals="interaction affordances" id="dfn-interaction-affordance"><span class="mark">相互作用のアフォーダンス</span></dfn>(Interaction Affordance)、<dfn data-dfn-type="dfn" data-plurals="properties" id="dfn-property"><span class="mark">Property</span></dfn>、<dfn data-dfn-type="dfn" data-plurals="actions" id="dfn-action"><span class="mark">Action</span></dfn>、<dfn data-dfn-type="dfn" data-plurals="events" id="dfn-event"><span class="mark">Event</span></dfn>、<dfn data-dfn-type="dfn" data-plurals="protocol bindings" id="dfn-protocol-binding">プロトコルバインディング</dfn>(Protocol Binding)、<dfn data-dfn-type="dfn" data-plurals="servients" id="dfn-servient"><span class="mark">Servient</span></dfn>、<dfn data-dfn-type="dfn" id="dfn-wot-interface">WoT インターフェース</dfn>(WoT Interface)、<dfn data-dfn-type="dfn" id="dfn-wot-runtime">WoT ランタイム</dfn>(WoT Runtime)などの基本的なWoT用語は、WoT アーキテクチャ仕様[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]の<a href="https://www.w3.org/TR/wot-architecture/#terminology">3項</a>で定義している。</p>
 
-<p>さらに、この仕様では次の定義を導入しています。</p>
+<p>さらに、この仕様では次の定義を導入している。</p>
 
 <dl>
   <dt><dfn id="dfn-context-ext" data-dfn-type="dfn" data-plurals="td context extensions">TDコンテキスト拡張</dfn>(TD Context Extension)</dt>
-  <dd><a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の追加により、<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>を拡張するメカニズム。これは、プロトコル・バインディング、セキュリティ・スキーム、データ・スキーマなどのコアなメカニズムに対するセマンティック・アノテーションと拡張の基礎です。</dd>
+  <dd><a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の追加により、<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>を拡張するメカニズム。これは、プロトコルバインディング、セキュリティスキーム、<span class="mark">Data Schema</span>などのコアなメカニズムに対するセマンティックアノテーションと拡張の基礎である。</dd>
   <dt><dfn id="dfn-inf-model" data-dfn-type="dfn">TD情報モデル</dfn>(TD Information Model)</dt>
-  <dd>制約が適用される定義済み<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>で構築される<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義の集合。したがって、その<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>のセマンティクスを定義します。クラス定義は通常、<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(一組の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>)と、その<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に関する機能で表現されます。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>には、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のグローバル関数として定義されている<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>も含まれています。</dd>
+  <dd>制約が適用される定義済み<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>で構築される<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義の集合。したがって、その<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>のセマンティクスを定義する。クラス定義は通常、<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(一組の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>)と、その<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に関する機能で表現される。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>には、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のグローバル関数として定義されている<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>も含まれている。</dd>
   <dt><dfn id="dfn-td-processor" data-dfn-type="dfn" data-plurals="td processors">TDプロセッサ</dfn>(TD Processor)</dt>
-  <dd>特定の形式で<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>の内部表現をシリアル化する、および/または、その形式から逆シリアル化することができるシステム。<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、セマンティック的に矛盾する<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>、つまり、<code>Thing</code>クラスの<a href="#dfn-instance-relation" class="internalDFN" data-link-type="dfn">インスタンス関係</a>の制約を満たすことができない<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>を検出しなければなりません。その目的のために、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、すべての可能な<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が割り当てられている正規形の<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>を計算できます。<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は通常、<a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn">WoTランタイム</a>のサブシステムです。TDプロセッサの実装は、TDの作成者のみ(TDドキュメントへのシリアル化が可能)またはTDの利用者のみ(TDドキュメントからの逆シリアル化が可能)です。</dd>
-  <dt><dfn id="dfn-td-serialization" data-dfn-type="dfn">TDシリアル化</dfn>(TD Serialization)または<dfn id="dfn-td-document" data-dfn-type="dfn" data-plurals="td documents">TDドキュメント</dfn>(TD Document)</dt>
-  <dd><a href="#dfn-servient" class="internalDFN" data-link-type="dfn">サービエント</a>間で保存および交換できる<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>のテキストまたはバイナリ表現。<a href="#dfn-td-serialization" class="internalDFN" data-link-type="dfn">TDシリアル化</a>は特定の表現形式に従い、ネットワーク上で交換される際にメディア・タイプによって識別されます。<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>のデフォルト表現形式は、この仕様で定義しているJSONベースです。</dd>
+  <dd>特定の形式で<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>の内部表現を<span class="mark">シリアライズ</span>および/または、その形式から<span class="mark">逆シリアライズ</span>することができるシステム。<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、セマンティック的に矛盾する<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>、つまり、<code>Thing</code>クラスの<a href="#dfn-instance-relation" class="internalDFN" data-link-type="dfn">インスタンス関係</a>の制約を満たすことができない<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>を検出しなければならない。その目的のために、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、すべての可能な<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が割り当てられている正規形の<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>を計算できる。<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は通常、<a href="#dfn-wot-runtime" class="internalDFN" data-link-type="dfn">WoT ランタイム</a>のサブシステムである。TDプロセッサの実装は、TDの作成者のみ(TDドキュメントへの<span class="mark">シリアライズ</span>が可能)またはTDの<span class="mark">消費者</span>のみ(TDドキュメントからの<span class="mark">逆シリアルライズ</span>が可能)である。</dd>
+  <dt><dfn id="dfn-td-serialization" data-dfn-type="dfn">TD<span class="mark">シリアライゼーション</span></dfn>(TD Serialization)または<dfn id="dfn-td-document" data-dfn-type="dfn" data-plurals="td documents">TDドキュメント</dfn>(TD Document)</dt>
+  <dd><a href="#dfn-servient" class="internalDFN" data-link-type="dfn"><span class="mark">Servient</span></a>間で保存および交換できる<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>のテキストまたはバイナリ表現。<a href="#dfn-td-serialization" class="internalDFN" data-link-type="dfn">TD<span class="mark">シリアライゼーション</span></a>は特定の表現形式に従い、ネットワーク上で交換される際にメディアタイプによって識別される。<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>のデフォルト表現形式は、この仕様で定義しているJSONベースである。</dd>
   <dt><dfn id="dfn-vocab" data-dfn-type="dfn" data-plurals="vocabularies">語彙</dfn>(Vocabulary)</dt>
   <dd>名前空間IRIで識別される<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>のコレクション。</dd>
   <dt><dfn id="dfn-term" data-dfn-type="dfn" data-plurals="terms">用語</dfn>(Term)および<dfn id="dfn-vocab-term" data-dfn-type="dfn" data-plurals="vocabulary terms">語彙用語</dfn>(Vocabulary Term)</dt>
-  <dd>文字列。<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>が<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の一部である場合、つまり、名前空間IRIが接頭辞として付与されている場合は、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>と呼ばれます。読みやすくするために、このドキュメントで示している<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>は、完全なIRIとしてではなく、常にコンパクトな形式で記述しています。</dd>
+  <dd>文字列。<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>が<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の一部である場合、つまり、名前空間IRIが接頭辞として付与されている場合は、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>と呼ばれる。読みやすくするために、このドキュメントで示している<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>は、完全なIRIとしてではなく、常にコンパクトな形式で記述している。</dd>
 </dl>
 
-<p>これらの定義については、<a href="#preliminary-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.2</bdi> 予備事項</a>でさらに展開します。</p>
+<p>これらの定義については、<a href="#preliminary-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.2</bdi> 予備事項</a>でさらに展開する。</p>
 
-  </section>
-  <section class="normative" id="namespaces">
+</section>
+<section class="normative" id="namespaces">
 
 <h2 id="x4-namespaces"><bdi class="secno">4.</bdi> 名前空間<a class="self-link" aria-label="§" href="#namespaces"></a></h2>
 
-<p>この仕様の<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で定義している<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のバージョンは、次のIRIで識別されます。</p>
+<p>この仕様の<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で定義している<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のバージョンは、次のIRIで識別される。</p>
 
 <p><code>https://www.w3.org/2019/wot/td/v1</code></p>
 
-<p>URI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]でもあるこのIRI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3987" title="Internationalized Resource Identifiers (IRIs)">RFC3987</a></cite>]は、<a href="https://www.w3.org/2019/wot/td/v1">JSON-LDコンテキスト・ファイル</a>[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]を取得するために逆参照でき、<a href="#dfn-td-document" class="internalDFN" data-link-type="dfn">TDドキュメント</a>のコンパクトな文字列をIRIベースの完全な<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>に展開できます。しかし、この処理は、JSONベースの<a href="#dfn-td-document" class="internalDFN" data-link-type="dfn">TDドキュメント</a>を、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>実装のオプション機能であるRDFに変換する場合にのみ必要です。</p>
+<p>URI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]でもあるこのIRI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3987" title="Internationalized Resource Identifiers (IRIs)">RFC3987</a></cite>]は、<a href="https://www.w3.org/2019/wot/td/v1">JSON-LDコンテキストファイル</a>[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]を取得するために逆参照でき、<a href="#dfn-td-document" class="internalDFN" data-link-type="dfn">TDドキュメント</a>のコンパクトな文字列をIRIベースの完全な<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>に展開できる。しかし、この処理は、JSONベースの<a href="#dfn-td-document" class="internalDFN" data-link-type="dfn">TDドキュメント</a>を、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>実装のオプション機能であるRDFに変換する場合にのみ必要である。</p>
 
-<p>現在の仕様では、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>は常にコンパクトな形式で示されます。その展開形式には、それが属している<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の名前空間IRI下でアクセスできます。この名前空間は、<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>の構造に従います。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>で用いられる個々の<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は、次のような独自の名前空間IRIを持っています。</p>
+<p>現在の仕様では、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>は常にコンパクトな形式で示される。その展開形式には、それが属している<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の名前空間IRI下でアクセスできる。この名前空間は、<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>の構造に従う。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>で用いられる個々の<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は、次のような独自の名前空間IRIを持っている。</p>
 
 <table class="def">
 <thead>
@@ -1419,7 +1425,7 @@
     <td><code>https://www.w3.org/2019/wot/td#</code></td>
   </tr>
   <tr>
-    <td>データ・スキーマ</td>
+    <td><span class="mark">Data Schema</span></td>
     <td><code>https://www.w3.org/2019/wot/json-schema#</code></td>
   </tr>
   <tr>
@@ -1433,33 +1439,33 @@
 </tbody>
 </table>
 
-<p><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は互いに独立しています。これらは、他の<abbr title="World Wide Web Consortium">W3C</abbr>仕様で再利用したり、拡張したりすることができます。<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の設計に互換性のない(breaking)変更を加えるたびに、年ベースの新しい名前空間URIの割り当てが必要になります。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の全般的な一貫性を維持するために、互換性のある(non-breaking)変更(特に新しい<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>の追加)も識別するように、関連するJSON-LDコンテキスト・ファイルは、すべてのバージョンが独自のURI(<code>v1</code>、<code>v1.1</code>、<code>v2</code>、...)を持つようにバージョン付けされていることに注意してください。</p>
+<p><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は互いに独立している。これらは、他の<abbr title="World Wide Web Consortium">W3C</abbr>仕様で再利用したり、拡張したりすることができる。<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の設計に互換性のない(breaking)変更を加えるたびに、年ベースの新しい名前空間URIの割り当てが必要になる。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の全般的な一貫性を維持するために、互換性のある(non-breaking)変更(特に新しい<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>の追加)も識別するように、関連するJSON-LDコンテキストファイルは、すべてのバージョンが独自のURI(<code>v1</code>、<code>v1.1</code>、<code>v2</code>、...)を持つようにバージョン付けされていることに注意していただきたい。</p>
 
-<p>ある名前空間IRI下の<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は、互換性のある変更しか行えないため、その内容を安全にキャッシュしたりアプリケーションに埋め込んだりすることができます。名前空間IRI下で比較的静的な内容を公開する利点の1つは、制約のあるデバイス間で交換されるメッセージのペイロード・サイズの最適化です。これにより、プライベート・ネットワークから公開されている語彙にアクセスするデバイスに起因するプライバシーの漏えいも回避されます(<a href="#sec-security-consideration-context" class="sec-ref">§&nbsp;<bdi class="secno">9.1</bdi> プライバシーのリスクを逆参照するコンテキスト</a>も参照)。</p>
+<p>ある名前空間IRI下の<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は、互換性のある変更しか行えないため、その内容を安全にキャッシュしたりアプリケーションに埋め込んだりすることができる。名前空間IRI下で比較的静的な内容を公開する利点の1つは、制約のあるデバイス間で交換されるメッセージのペイロードサイズの最適化である。これにより、プライベートネットワークから公開されている語彙にアクセスするデバイスに起因するプライバシーの漏えいも回避される(<a href="#sec-security-consideration-context" class="sec-ref">§&nbsp;<bdi class="secno">9.1</bdi> プライバシーのリスクを逆参照するコンテキスト</a>も参照)。</p>
 
 </section>
 <section id="sec-vocabulary-definition" class="normative">
 
 <h2 id="x5-td-information-model"><bdi class="secno">5.</bdi> TD情報モデル<a class="self-link" aria-label="§" href="#sec-vocabulary-definition"></a></h2>
 
-<p>この項では、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>について紹介します。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、「<a href="#sec-td-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.</bdi> TD表現形式</a>」で別個に説明している、モノの記述の処理とそのシリアル化の概念的な基盤として機能します。</p>
+<p>この項では、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>について紹介する。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、「<a href="#sec-td-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.</bdi> TD表現形式</a>」で別個に説明している、<span class="mark">Thing Description</span>の処理とその<span class="mark">シリアライゼーション</span>の概念的な基盤として機能する。</p>
 
 <section id="overview">
 
 <h3 id="x5-1-overview"><bdi class="secno">5.1</bdi> 概要<a class="self-link" aria-label="§" href="#overview"></a></h3>
 
-<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、次の独立した<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>に基づいて構築されます。</p>
+<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、次の独立した<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>に基づいて構築される。</p>
 
 <ul>
-  <li><em>コア</em>TD<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。<a href="#dfn-property" class="internalDFN" data-link-type="dfn">プロパティー</a>、<a href="#dfn-action" class="internalDFN" data-link-type="dfn">アクション</a>、<a href="#dfn-event" class="internalDFN" data-link-type="dfn">イベント</a>の<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>の<a href="#dfn-interaction-model" class="internalDFN" data-link-type="dfn">対話モデル</a>を反映する[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]。</li>
-  <li><em>データ・スキーマ</em><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。JSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている用語(のサブセット)を含む。</li>
-  <li><em>WoTセキュリティ</em><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。セキュリティ・メカニズムとその設定要件を識別する。</li>
-  <li><em>ハイパーメディア制御</em><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。ウェブ・リンクとフォームを用いたRESTfulな通信の主要な原則をエンコードする。</li>
+  <li><em>コア</em>TD <a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。<a href="#dfn-property" class="internalDFN" data-link-type="dfn"><span class="mark">Property</span></a>、<a href="#dfn-action" class="internalDFN" data-link-type="dfn"><span class="mark">Action</span></a>、<a href="#dfn-event" class="internalDFN" data-link-type="dfn"><span class="mark">Event</span></a>の<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>の<a href="#dfn-interaction-model" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用モデル</span></a>を反映する[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]。</li>
+  <li><em><span class="mark">Data Schema</span></em><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。JSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている用語(のサブセット)を含む。</li>
+  <li><em>WoTセキュリティ</em><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。セキュリティメカニズムとその<span class="mark">構成</span>要件を識別する。</li>
+  <li><em>ハイパーメディア制御</em><a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>。ウェブリンクとフォームを用いたRESTfulな通信の主要な原則をエンコードする。</li>
 </ul>
 
-<p>これらの<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>はそれぞれ、基本的にデータ構造の構築に使用できる<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>の集合であり、従来のオブジェクト指向の意味のオブジェクトとして解釈されます。オブジェクトはクラスのインスタンスであり、プロパティーを持ちます。<abbr title="World Wide Web Consortium">W3C</abbr> WoTのコンテキストでは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>とその<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>を示します。オブジェクトの正式な定義を<a href="#preliminary-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.2</bdi> 予備事項</a>で示しています。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の主要な要素は、<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>で示しています。<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が存在している場合は、特定のオブジェクト・プロパティーをTDで省略できます。デフォルトのリストは、<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>で示しています。</p>
+<p>これらの<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>はそれぞれ、基本的にデータ構造の構築に使用できる<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>の集合であり、従来のオブジェクト指向の意味のオブジェクトとして解釈される。オブジェクトはクラスのインスタンスであり、プロパティーを持つ。<abbr title="World Wide Web Consortium">W3C</abbr> WoTのコンテキストでは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>とその<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>を示す。オブジェクトの正式な定義を<a href="#preliminary-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.2</bdi> 予備事項</a>で示している。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の主要な要素は、<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>で示している。<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が存在している場合は、特定のオブジェクトプロパティーをTDで省略できき。デフォルトのリストは、<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>で示す。</p>
 
-<p>次に示すUML図は、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の概要を示しています。すべてのクラスを表として表しており、<a href="#thing"><code>Thing</code></a>というクラスから始まる、クラス間に存在する関連付けを有向の矢印として表しています。読みやすくするために、図は、4つの基本<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>ごとに1つずつの、4つの部分に分割しています。</p>
+<p>次に示すUML図は、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の概要を示している。すべてのクラスを表として表しており、<a href="#thing"><code>Thing</code></a>というクラスから始まる、クラス間に存在する関連付けを有向の矢印として表している。読みやすくするために、図は、4つの基本<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>ごとに1つずつの、4つの部分に分割している。</p>
 
 <figure id="td-core-model">
 <img src="images/td.png" alt="TDコア語彙のTD情報モデルのUML図">
@@ -1469,8 +1475,8 @@
 <hr>
 
 <figure id="td-data-schema-model">
-<img src="images/json-schema.png" alt="データ・スキーマ語彙のTD情報モデルのUML図">
-<figcaption>図<bdi class="figno">2</bdi> <span class="fig-title">データ・スキーマ語彙</span></figcaption>
+<img src="images/json-schema.png" alt="データスキーマ語彙のTD情報モデルのUML図">
+<figcaption>図<bdi class="figno">2</bdi> <span class="fig-title"><span class="mark">データスキーマ</span>語彙</span></figcaption>
 </figure>
 
 <hr>
@@ -1492,48 +1498,48 @@
 
 <h3 id="x5-2-preliminaries"><bdi class="secno">5.2</bdi> 予備事項<a class="self-link" aria-label="§" href="#preliminary-definitions"></a></h3>
 
-<p>ツリー・ベースのドキュメントに関するシンプルな規則(つまり、未加工のJSONの処理)と、豊かなセマンティック・ウェブ・ツール(つまり、JSON-LD処理)の両方で容易に処理できるモデルを提供するために、このドキュメントでは、次の形式的な予備事項を定義し、それに応じて<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>を構築します。</p>
+<p>ツリーベースのドキュメントに関するシンプルな規則(つまり、未加工のJSONの処理)と、豊かなセマンティックウェブツール(つまり、JSON-LD処理)の両方で容易に処理できるモデルを提供するために、このドキュメントでは、次の形式的な予備事項を定義し、それに応じて<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>を構築する。</p>
 
-<p>この項のすべての定義は<em>集合</em>を意味しており、それは直感的に、それ自身が集合になり得る要素のコレクションです。任意の複雑なデータ構造はすべて集合として定義できます。特に、<dfn data-dfn-type="dfn" data-plurals="objects" id="dfn-object">オブジェクト</dfn>は、次のとおりに帰納的に定義されたデータ構造です。</p>
+<p>この項のすべての定義は<em>集合</em>を意味しており、それは直感的に、それ自身が集合になり得る要素のコレクションである。任意の複雑なデータ構造はすべて集合として定義できる。特に、<dfn data-dfn-type="dfn" data-plurals="objects" id="dfn-object">オブジェクト</dfn>は、次のとおりに帰納的に定義されたデータ構造である。</p>
 
 <ul>
   <li><a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>は、<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>に属していてもいなくても、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>である。</li>
   <li>名前が<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>で値が別の<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>である名前-値のペアも、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>である。</li>
 </ul>
 
-<p>この定義は<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>が同じ名前の複数の名前-値のペアを含むことを妨げませんが、これは一般的にこの仕様では検討しません。要素の名前が数字のみである<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>を<dfn data-dfn-type="dfn" data-plurals="arrays" id="dfn-array">配列</dfn>と呼びます。同様に、要素が<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>(いかなる<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>にも属さない)のみを名前として持つ<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>を<dfn data-dfn-type="dfn" data-plurals="maps" id="dfn-map">マップ</dfn>と呼びます。<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>内の名前-値のペアに現れるすべての名前は、その<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>の範囲内で<em>一意</em>であると見なされます。</p>
+<p>この定義は<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>が同じ名前の複数の名前-値のペアを含むことを妨げないが、これは一般的にこの仕様では検討しない。要素の名前が数字のみである<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>を<dfn data-dfn-type="dfn" data-plurals="arrays" id="dfn-array">配列</dfn>と呼ぶ。同様に、要素が<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>(いかなる<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>にも属さない)のみを名前として持つ<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>を<dfn data-dfn-type="dfn" data-plurals="maps" id="dfn-map">マップ</dfn>と呼ぶ。<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>内の名前-値のペアに現れるすべての名前は、その<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>の範囲内で<em>一意</em>であると見なされる。</p>
 
-<p>さらに、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は<dfn data-dfn-type="dfn" data-plurals="classes" id="dfn-class">クラス</dfn>のインスタンスになりえます。<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で示される<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>は、<dfn data-dfn-type="dfn" data-plurals="signatures" id="dfn-signature">シグネチャ</dfn>と呼ばれる一組の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で最初に定義されます。<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>が空の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>は、<dfn data-dfn-type="dfn" data-plurals="simple types" id="dfn-simple-type">単純型</dfn>と呼ばれます。</p>
+<p>さらに、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は<dfn data-dfn-type="dfn" data-plurals="classes" id="dfn-class">クラス</dfn>のインスタンスになりえる。<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で示される<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>は、<dfn data-dfn-type="dfn" data-plurals="signatures" id="dfn-signature">シグネチャ</dfn>と呼ばれる一組の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で最初に定義される。<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>が空の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>は、<dfn data-dfn-type="dfn" data-plurals="simple types" id="dfn-simple-type">単純型</dfn>と呼ばれる。</p>
 
-<p><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>により、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を詳細に定義した2つの関数(<dfn data-dfn-type="dfn" id="dfn-assignment-function">割り当て関数</dfn>と<dfn data-dfn-type="dfn" id="dfn-type-function">型関数</dfn>)を構築できます。<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を入力として取り、<code>true</code>または<code>false</code>を出力として返します。直感的には、<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>をインスタンス化するときに<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>の要素が必須かオプションかを示します。<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-type-function" class="internalDFN" data-link-type="dfn">型関数</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を入力として取り、別の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を出力として返します。これらの関数は<em>部分的</em>です。それらの定義域は定義されている<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に制限されます。</p>
+<p><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>により、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を詳細に定義した2つの関数(<dfn data-dfn-type="dfn" id="dfn-assignment-function">割り当て関数</dfn>と<dfn data-dfn-type="dfn" id="dfn-type-function">型関数</dfn>)を構築できる。<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を入力として取り、<code>true</code>または<code>false</code>を出力として返す。直感的には、<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>をインスタンス化するときに<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>の要素が必須かオプションかを示す。<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-type-function" class="internalDFN" data-link-type="dfn">型関数</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を入力として取り、別の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を出力として返す。これらの関数は<em>部分的</em>である。それらの定義域は定義されている<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に制限される。</p>
 
-<p>これらの2つの関数に基づいて、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>と<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>で構成されるペアに対して<dfn data-dfn-type="dfn" id="dfn-instance-relation">インスタンス関係</dfn>を定義できます。この関係は、満たすべき制約と定義されています。つまり、次の2つの制約が<em>両方とも</em>満たされる場合、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスになります。</p>
+<p>これらの2つの関数に基づいて、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>と<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>で構成されるペアに対して<dfn data-dfn-type="dfn" id="dfn-instance-relation">インスタンス関係</dfn>を定義できる。この関係は、満たすべき制約と定義されている。つまり、次の2つの制約が<em>両方とも</em>満たされる場合、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスになる。</p>
 
 <ul>
   <li><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>が<code>true</code>を返すすべての<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>に対し、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前とする名前-値のペアが<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>に含まれている。</li>
   <li><a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>の名前-値のペアで名前として用いられる<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>のすべての<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>に対し、そのペアの値は、特定の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>に対する<a href="#dfn-type-function" class="internalDFN" data-link-type="dfn">型関数</a>によって返される<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスである。</li>
 </ul>
 
-<p>上記の定義によれば、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は、その構造に関係なく、すべての<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>のインスタンスになります。代わりに、<a href="#dfn-instance-relation" class="internalDFN" data-link-type="dfn">インスタンス関係</a>の別の定義が<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>に導入されています。<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は、特定の字句形式を持つ<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>である場合、<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>のインスタンスです(例えば、<code>boolean</code>型の場合は<code>true</code>、<code>false</code>で、<code>unsignedInt</code>型の場合は<code>1</code>、<code>2</code>、<code>3</code>...など)。</p>
+<p>上記の定義によれば、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は、その構造に関係なく、すべての<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>のインスタンスになる。代わりに、<a href="#dfn-instance-relation" class="internalDFN" data-link-type="dfn">インスタンス関係</a>の別の定義が<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>に導入されている。<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は、特定の字句形式を持つ<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>である場合、<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>のインスタンスである(例えば、<code>boolean</code>型の場合は<code>true</code>、<code>false</code>で、<code>unsignedInt</code>型の場合は<code>1</code>、<code>2</code>、<code>3</code>...など)。</p>
 
-<p>さらに、<dfn data-dfn-type="dfn" id="dfn-parameterized-classes">パラメータ化されたクラス</dfn>と呼ばれる追加の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を、汎用的な<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>と<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>の構造から派生させることができます。<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は、含んでいるすべての名前-値のペアの値がこの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスであるような<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>である場合、何らかの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>、つまり、何らかの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>で<em>パラメータ化された</em><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>型のインスタンスです。同じことが<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>にも当てはまります。</p>
+<p>さらに、<dfn data-dfn-type="dfn" id="dfn-parameterized-classes">パラメータ化されたクラス</dfn>と呼ばれる追加の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を、汎用的な<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>と<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>の構造から派生させることができる。<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は、含んでいるすべての名前-値のペアの値がこの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスであるような<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>である場合、何らかの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>、つまり、何らかの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>で<em>パラメータ化された</em><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>型のインスタンスである。同じことが<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>にも当てはまる。</p>
 
-<p>最後に、前者のすべてのインスタンスが後者のインスタンスでもある場合、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>は他の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<dfn data-dfn-type="dfn" data-plurals="subclasses" id="dfn-subclass">サブクラス</dfn>になります。</p>
+<p>最後に、前者のすべてのインスタンスが後者のインスタンスでもある場合、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>は他の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<dfn data-dfn-type="dfn" data-plurals="subclasses" id="dfn-subclass">サブクラス</dfn>になる。</p>
 
-<p>上記のすべての定義を前提とすると、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名(<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>)、<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の集合)、<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>、および<a href="#dfn-type-function" class="internalDFN" data-link-type="dfn">型関数</a>を含む、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義の集合と理解されます。これらの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の定義は、<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>の表として提供しています。各表では、割り当ての列の「必須」の値(または「オプション」)は、<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>が対応する<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>に対して<code>true</code>(または<code>false</code>)を返すことを示しています。</p>
+<p>上記のすべての定義を前提とすると、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名(<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>)、<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の集合)、<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>、および<a href="#dfn-type-function" class="internalDFN" data-link-type="dfn">型関数</a>を含む、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義の集合と理解される。これらの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の定義は、<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>の表として提供している。各表では、割り当ての列の「必須」の値(または「オプション」)は、<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>が対応する<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>に対して<code>true</code>(または<code>false</code>)を返すことを示している。</p>
 
-<p>慣例により、<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>は小文字で始まる名前で示されます。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、XMLスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-xmlschema11-2-20120405" title="W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes">XMLSCHEMA11-2-20120405</a></cite>]で定義されている、<code>string</code>、<code>anyURI</code>、<code>dateTime</code>, <code>integer</code>、<code>unsignedInt</code>, <code>double</code>、<code>boolean</code>という<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>を参照します。それらの定義(つまり、字句形式の仕様)は、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の範囲外です。</p>
+<p>慣例により、<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>は小文字で始まる名前で示される。<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、XMLスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-xmlschema11-2-20120405" title="W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes">XMLSCHEMA11-2-20120405</a></cite>]で定義されている、<code>string</code>、<code>anyURI</code>、<code>dateTime</code>, <code>integer</code>、<code>unsignedInt</code>, <code>double</code>、<code>boolean</code>という<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>を参照する。それらの定義(つまり、字句形式の仕様)は、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の範囲外である。</p>
 
-<p>さらに、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>のペアにおけるグローバル関数を定義します。この関数は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名と別の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を入力として取り、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>を返します。返された<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>が<code>null</code>ではない場合、それは入力<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスの入力<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の割り当てに対する<dfn data-dfn-type="dfn" data-plurals="default values" id="dfn-default-value">デフォルト値</dfn>を表します。この関数により、上記の<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>で定義している制約を緩和できます。すべての必須の割り当てが含まれている場合、<em>または</em>欠落している割り当てに<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が存在する場合、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスです。すべての<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>の表で示しています。<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>の各表には、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>と<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の対応する組み合わせに<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が使用可能な場合に、割り当て列に「デフォルトあり」という値が含まれています。</p>
+<p>さらに、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>のペアにおけるグローバル関数を定義する。この関数は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名と別の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を入力として取り、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>を返す。返された<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>が<code>null</code>ではない場合、それは入力<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスの入力<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の割り当てに対する<dfn data-dfn-type="dfn" data-plurals="default values" id="dfn-default-value">デフォルト値</dfn>を表す。この関数により、上記の<a href="#dfn-assignment-function" class="internalDFN" data-link-type="dfn">割り当て関数</a>で定義している制約を緩和できる。すべての必須の割り当てが含まれている場合、<em>または</em>欠落している割り当てに<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が存在する場合、<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>は<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスである。すべての<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>の表で示している。<a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラスの定義</a>の各表には、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>と<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の対応する組み合わせに<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が使用可能な場合に、割り当て列に「デフォルトあり」という値が含まれている。</p>
 
-<p>ここで紹介している形式化では、抽象的なデータ構造としての<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>と、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>などの物理世界のオブジェクトとの、ありえる関係を考慮していません。しかし、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>に含まれるすべての<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>をRDF資源として再解釈し、物理世界のより大きなモデル(オントロジー)に統合する可能性には注意を払いました。セマンティックな処理の詳細に関しては、<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> JSON-LDコンテキストの使用法</a>や、<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下にあるドキュメントを参照してください。</p>
+<p>ここで紹介している形式化では、抽象的なデータ構造としての<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>と、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>などの物理世界のオブジェクトとの、ありえる関係を考慮していない。しかし、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>に含まれるすべての<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>をRDF資源として再解釈し、物理世界のより大きなモデル(オントロジー)に統合する可能性には注意を払った。セマンティックな処理の詳細に関しては、<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> JSON-LDコンテキストの使用法</a>や、<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下にあるドキュメントを参照していただきたい。</p>
 
 </section>
 <section id="class-definitions">
 
 <h3 id="x5-3-class-definitions"><bdi class="secno">5.3</bdi> クラスの定義<a class="self-link" aria-label="§" href="#class-definitions"></a></h3>
 
-<p><span class="rfc2119-assertion" id="td-processor"><a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、<a href="#sec-core-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1</bdi> コア語彙の定義</a>、<a href="#sec-data-schema-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.2</bdi> データ・スキーマ語彙の定義</a>、<a href="#sec-security-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義</a>、および<a href="#sec-hypermedia-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.4</bdi> ハイパーメディア制御語彙の定義</a>で定義しているすべての<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>・インスタンス化の制約を満たさなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-processor"><a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、<a href="#sec-core-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1</bdi> コア語彙の定義</a>、<a href="#sec-data-schema-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.2</bdi> <span class="mark">Data Schema</span>語彙の定義</a>、<a href="#sec-security-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義</a>、および<a href="#sec-hypermedia-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.4</bdi> ハイパーメディア制御語彙の定義</a>で定義しているすべての<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>インスタンス化の制約を満たさなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 <section id="sec-core-vocabulary-definition">
 
@@ -1541,9 +1547,9 @@
 
 <section id="thing">
 
-<h5 id="x5-3-1-1-thing"><bdi class="secno">5.3.1.1</bdi> <code>Thing</code>(モノ)<a class="self-link" aria-label="§" href="#thing"></a></h5>
+<h5 id="x5-3-1-1-thing"><bdi class="secno">5.3.1.1</bdi> <code>Thing</code><a class="self-link" aria-label="§" href="#thing"></a></h5>
 
-<p>WoTモノの記述でメタデータとインターフェースが記述されている物理エンティティーまたは仮想エンティティーの抽象化。それに対し、仮想エンティティーは1つ以上のモノの合成物です。</p>
+<p><span class="mark">WoT Thing Description</span>でメタデータとインターフェースが記述されている物理エンティティーまたは仮想エンティティーの抽象化。それに対し、仮想エンティティーは1つ以上の<span class="mark">Thing</span>の合成物である。</p>
 
 <table class="def">
 <thead>
@@ -1563,120 +1569,120 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-at-type--Thing">
     <td><code>@type</code></td>
-    <td>セマンティック・タグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
+    <td>セマンティックタグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-id--Thing">
     <td><code>id</code></td>
-    <td>URI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]形式のモノの識別子(例えば、安定したURI、一時的かつ可変なURI、ローカルなIPアドレスを持つURI、URNなど)。</td>
+    <td>URI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]形式の<span class="mark">Thing</span>の識別子(例えば、安定したURI、一時的かつ可変なURI、ローカルなIPアドレスを持つURI、URNなど)。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-title--Thing">
     <td><code>title</code></td>
-    <td>デフォルトの言語に基づいて、人間が読めるタイトルを提供します(例えば、UI表現用のテキストを表示)。</td>
+    <td>デフォルトの言語に基づいて、人間が読めるタイトルを提供する(例えば、UI表現用のテキストを表示)。</td>
     <td>必須</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-titles--Thing">
     <td><code>titles</code></td>
-    <td>多言語の人間が読めるタイトルを提供します(例えば、様々な言語でUI表現のテキストを表示)。</td>
+    <td>多言語の人間が読めるタイトルを提供する(例えば、様々な言語でUI表現のテキストを表示)。</td>
     <td>オプション</td>
     <td><a href="#multilanguage"><code>MultiLanguage</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-description--Thing">
     <td><code>description</code></td>
-    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供します。</td>
+    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--Thing">
     <td><code>descriptions</code></td>
-    <td>様々な言語の(人間が読める)情報をサポートするために使用できます。</td>
+    <td>様々な言語の(人間が読める)情報をサポートするために使用できる。</td>
     <td>オプション</td>
     <td><a href="#multilanguage"><code>MultiLanguage</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-version--Thing">
     <td><code>version</code></td>
-    <td>バージョン情報を提供します。</td>
+    <td>バージョン情報を提供する。</td>
     <td>オプション</td>
     <td><a href="#versioninfo"><code>VersionInfo</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-created--Thing">
     <td><code>created</code></td>
-    <td>TDのインスタンスがいつ作成されたかの情報を提供します。</td>
+    <td>TDのインスタンスがいつ作成されたかの情報を提供する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-modified--Thing">
     <td><code>modified</code></td>
-    <td>TDのインスタンスがいつ最終的に変更されたかの情報を提供します。</td>
+    <td>TDのインスタンスがいつ最終的に変更されたかの情報を提供する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#dateTime"><code>dateTime</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-support--Thing">
     <td><code>support</code></td>
-    <td>TDの管理者に関する情報をURIスキーム(例えば、<code>mailto</code>[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6068" title="The 'mailto' URI Scheme">RFC6068</a></cite>]、<code>tel</code>[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3966" title="The tel URI for Telephone Numbers">RFC3966</a></cite>]、<code>https</code>)として提供します。</td>
+    <td>TDの管理者に関する情報をURIスキーム(例えば、<code>mailto</code>[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6068" title="The 'mailto' URI Scheme">RFC6068</a></cite>]、<code>tel</code>[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3966" title="The tel URI for Telephone Numbers">RFC3966</a></cite>]、<code>https</code>)として提供する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-base--Thing">
     <td><code>base</code></td>
-    <td>TDドキュメント全体のすべての相対URI参照に用いる基底URIを定義します。TDのインスタンス内では、[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]で定義されているアルゴリズムを用いて、すべての相対URIが基底URIに対して相対的に解決されます。<br>
+    <td>TDドキュメント全体のすべての相対URI参照に用いる基底URIを定義する。TDのインスタンス内では、[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]で定義されているアルゴリズムを用いて、すべての相対URIが基底URIに対して相対的に解決される。<br>
 <br>
-<code>base</code>は、<code>@context</code>内で用いられるURIと、TDのインスタンスにセマンティックな処理が適用されるときに関連があるリンクト・データ[<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>]のグラフ内で用いられるIRIには影響を与えません。</td>
+<code>base</code>は、<code>@context</code>内で用いられるURIと、TDのインスタンスにセマンティックな処理が適用されるときに関連があるリンクトデータ[<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>]のグラフ内で用いられるIRIには影響を与えない。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-properties--Thing">
     <td><code>properties</code></td>
-    <td>モノのすべてのプロパティー・ベースの<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>。</td>
+    <td><span class="mark">Thing</span>のすべての<span class="mark">Property</span>ベースの<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>。</td>
     <td>オプション</td>
     <td><a href="#propertyaffordance"><code>PropertyAffordance</code></a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-actions--Thing">
     <td><code>actions</code></td>
-    <td>モノのすべてのアクション・ベースの<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>。</td>
+    <td><span class="mark">Thing</span>のすべての<span class="mark">Action</span>ベースの<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>。</td>
     <td>オプション</td>
     <td><a href="#actionaffordance"><code>ActionAffordance</code></a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-events--Thing">
     <td><code>events</code></td>
-    <td>モノのすべてのイベント・ベースの<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>。</td>
+    <td><span class="mark">Thing</span>のすべての<span class="mark">Event</span>ベースの<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>。</td>
     <td>オプション</td>
     <td><a href="#eventaffordance"><code>EventAffordance</code></a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-links--Thing">
     <td><code>links</code></td>
-    <td>指定されたモノの記述に関連する任意の資源へのウェブ・リンクを提供します。</td>
+    <td>指定された<span class="mark">Thing Description</span>に関連する任意の資源へのウェブリンクを提供する。</td>
     <td>オプション</td>
     <td><a href="#link"><code>Link</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-forms--Thing">
     <td><code>forms</code></td>
-    <td><span>操作の実行方法を記述する、フォームのハイパーメディア制御の集合。フォームは、プロトコル・バインディングのシリアル化です。</span>このバージョンのTDでは、モノのレベルで記述できるすべての操作は、モノの<a href="#propertyaffordance">プロパティー</a>と一度にまとめて対話する方法に関するものです。</td>
+    <td><span>操作の実行方法を記述する、フォームのハイパーメディア制御の集合。フォームは、プロトコルバインディングの<span class="mark">シリアライゼーション</span>である。</span>このバージョンのTDでは、<span class="mark">Thing</span>のレベルで記述できるすべての操作は、<span class="mark">Thing</span>の<a href="#propertyaffordance"><span class="mark">Property</span></a>と一度にまとめて相互作用する方法に関するものである。</td>
     <td>オプション</td>
     <td><a href="#form"><code>Form</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-security--Thing">
     <td><code>security</code></td>
-    <td>セキュリティ定義名の集合。<code>securityDefinitions</code>で定義されているものから選定します。資源にアクセスするためには、これらすべてが満たされていなければなりません。</td>
+    <td>セキュリティ定義名の集合。<code>securityDefinitions</code>で定義されているものから選定する。資源にアクセスするためには、これらすべてが満たされていなければならない。</td>
     <td>必須</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-securityDefinitions--Thing">
     <td><code>securityDefinitions</code></td>
-    <td>名前付きセキュリティ設定(定義のみ)の集合。<code>security</code>の名前-値のペアで名前が用いられていなければ、実際には適用されません。</td>
+    <td>名前付きセキュリティ<span class="mark">構成情報</span>(定義のみ)の集合。<code>security</code>の名前-値のペアで名前が用いられていなければ、実際には適用されない。</td>
     <td>必須</td>
     <td><a href="#securityscheme"><code>SecurityScheme</code></a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a></td>
   </tr>
 </tbody>
 </table>
 
-<p><span class="rfc2119-assertion" id="td-context-ns-thing-mandatory"><code>@context</code>の名前-値のペアには、<code>anyURI</code>型の場合は直接、<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型の場合は最初の要素として、anyURIである<code>https://www.w3.org/2019/wot/td/v1</code>を含めなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-context-ns-thing-optional"><code>@context</code>が<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>である場合は、anyURIである<code>https://www.w3.org/2019/wot/td/v1</code>の後に<code>anyURI</code>型または<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>型の要素を任意の順序で置くことができますが(<em class="rfc2119" title="MAY">MAY</em>)、<code>@context</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内には、すべての名前-値のペアを持つ<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>を1つだけ含めることをお勧めします(<em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>)。</span><span class="rfc2119-assertion" id="td-context-ns-thing-map-of-namespaces">値が<code>anyURI</code>型の名前空間識別子であり、名前がその名前空間を示す<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>または接頭辞である場合、<code>@context</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>に含まれる<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>には、名前-値のペアを含めることができます(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="td-context-default-language">名前が<code>@language</code>という<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>で、値が[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で定義されている整形式の言語タグである場合(例えば、<code>en</code>、<code>de-AT</code>、<code>gsw-CH</code>、<code>zh-Hans</code>、<code>zh-Hant-HK</code>、<code>sl-nedis</code>)、<code>@context</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>に含まれる1つの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>には、モノの記述のデフォルト言語を定義する名前-値のペアを含めるべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-context-ns-thing-mandatory"><code>@context</code>の名前-値のペアには、<code>anyURI</code>型の場合は直接、<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型の場合は最初の要素として、anyURIである<code>https://www.w3.org/2019/wot/td/v1</code>を含めなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-context-ns-thing-optional"><code>@context</code>が<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>である場合は、anyURIである<code>https://www.w3.org/2019/wot/td/v1</code>の後に<code>anyURI</code>型または<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>型の要素を任意の順序で置くことができるが(<em class="rfc2119" title="MAY">MAY</em>)、<code>@context</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内には、すべての名前-値のペアを持つ<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>を1つだけ含めることをお勧めする(<em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>)。</span><span class="rfc2119-assertion" id="td-context-ns-thing-map-of-namespaces">値が<code>anyURI</code>型の名前空間識別子であり、名前がその名前空間を示す<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>または接頭辞である場合、<code>@context</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>に含まれる<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>には、名前-値のペアを含めることができる(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="td-context-default-language">名前が<code>@language</code>という<a href="#dfn-term" class="internalDFN" data-link-type="dfn">用語</a>で、値が[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で定義されている整形式の言語タグである場合(例えば、<code>en</code>、<code>de-AT</code>、<code>gsw-CH</code>、<code>zh-Hans</code>、<code>zh-Hant-HK</code>、<code>sl-nedis</code>)、<code>@context</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>に含まれる1つの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>には、<span class="mark">Thing Description</span>のデフォルト言語を定義する名前-値のペアを含めるべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
 
-<p>人間が読めるすべてのテキスト文字列の基本書字方向の計算は、次の一連の規則によって定義されます。</p>
+<p>人間が読めるすべてのテキスト文字列の基本書字方向の計算は、次の一連の規則によって定義される。</p>
 
 <ul>
   <li><span class="rfc2119-assertion" id="td-context-default-language-direction-heuristic">言語タグが指定されていない場合は、基本書字方向は、最初の強い文字(first-strong)のヒューリスティクスまたはCLDR Likely Subtags[<cite><a class="bibref" data-link-type="biblio" href="#bib-ldml" title="Unicode Technical Standard #35: Unicode Locale Data Markup Language (LDML)">LDML</a></cite>]などの検出アルゴリズムによって推測されるべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></li>
@@ -1685,24 +1691,24 @@
   <li><span class="rfc2119-assertion" id="td-context-default-language-direction-script">異なる基本書字方向を持つ複数のスクリプトで言語を記述できる場合、<code>@language</code>または<code>MultiLanguage</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>で指定されている対応する言語タグには、適切な基本書字方向を推測できるように、文字のサブタグを含めなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>例は、アゼルバイジャン語(Azeri)で、ラテン文字を用いる場合(<code>az-Latn</code>を用いて指定)はLTRで、アラビア文字を用いる場合(<code>az-Arab</code>を用いて指定)はRTLで記述される。</li>
 </ul>
 
-<p><a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、双方向テキストを処理する際に、特定の特殊なケースに注意すべきです。ユーザに文字列を提示する際に、特に周囲のテキストに埋め込むときには(例えば、ウェブ・ユーザ・インターフェース用に)、bidi分離(bidi isolation)を用いるように注意すべきです。言語が正しく識別されたとしても、方向が混在する文はどの言語においても発生しえます。</p>
+<p><a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、双方向テキストを処理する際に、特定の特殊なケースに注意すべきである。ユーザに文字列を提示する際に、特に周囲のテキストに埋め込むときには(例えば、ウェブユーザインターフェース用に)、bidi分離(bidi isolation)を用いるように注意すべきである。言語が正しく識別されたとしても、方向が混在する文はどの言語においても発生しえる。</p>
 
-<p>TDの作成者は、未熟なユーザ・エージェントが正常に表示できる方法で、方向が混合する文字列を提供するように努めるべきです。例えば、RTLの文字列がLTR進行で始まる場合(ラテン文字の数字、ブランド名や商号など)、文字列の先頭にRLMの文字を含めるか、逆方向の進行をbidi制御でラップすることで適切な表示をサポートできます。</p>
+<p>TDの作成者は、未熟なユーザエージェントが正常に表示できる方法で、方向が混合する文字列を提供するように努めるべきである。例えば、RTLの文字列がLTR進行で始まる場合(ラテン文字の数字、ブランド名や商号など)、文字列の先頭にRLMの文字を含めるか、逆方向の進行をbidi制御でラップすることで適切な表示をサポートできる。</p>
 
-<p><em>ウェブの文字列: 言語と方向のメタデータ</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta" title="Strings on the Web: Language and Direction Metadata">string-meta</a></cite>]は、ガイダンスを提供し、双方向テキストを用いる場合のいくつかの落とし穴を例示しています。</p>
+<p><em>ウェブの文字列: 言語と方向のメタデータ</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta" title="Strings on the Web: Language and Direction Metadata">string-meta</a></cite>]は、ガイダンスを提供し、双方向テキストを用いる場合のいくつかの落とし穴を例示している。</p>
 
-<p id="meta-interactions-of-thing"><code>properties</code>(プロパティー)、<code>actions</code>(アクション)、および<code>events</code>(イベント)の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>で明示的に提供される<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>に加えて、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、オプションの<code>forms</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>で<code>Form</code>インスタンスによって示されるメタ対話も提供できます。<span class="rfc2119-assertion" id="td-op-for-thing"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のインスタンスの<code>forms</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>に<code>Form</code>インスタンスが含まれている場合、<code>op</code>という名前に直接的に、または<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内で割り当てられている文字列の値は、<code>readallproperties</code>、<code>writeallproperties</code>、<code>readmultipleproperties</code>、または<code>writemultipleproperties</code>のいずれかの<em>操作型</em>の1つでなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span>(モノのインスタンス内の<code>form</code>の使用<a href="#td-forms-readall-example">例</a>を参照してください。)</p>
+<p id="meta-interactions-of-thing"><code>properties</code>(プロパティー)、<code>actions</code>(アクション)、および<code>events</code>(イベント)の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>で明示的に提供される<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>に加えて、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は、オプションの<code>forms</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>で<code>Form</code>インスタンスによって示されるメタ相互作用も提供できる。<span class="rfc2119-assertion" id="td-op-for-thing"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のインスタンスの<code>forms</code><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>に<code>Form</code>インスタンスが含まれている場合、<code>op</code>という名前に直接的に、または<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内で割り当てられている文字列の値は、<code>readallproperties</code>、<code>writeallproperties</code>、<code>readmultipleproperties</code>、または<code>writemultipleproperties</code>のいずれかの<em>操作型</em>の1つでなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>(<span class="mark">Thing</span>のインスタンス内の<code>form</code>の使用<a href="#td-forms-readall-example">例</a>を参照。)</p>
 
-<p><code>ObjectSchema</code>インスタンスの<code>properties</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>に、対応する<code>PropertyAffordances</code>インスタンスの名前で識別される<code>PropertyAffordances</code>の各データ・スキーマが含まれている場合、これらのメタ対話ごとのデータ・スキーマは、各<code>PropertyAffordance</code>インスタンスのデータ・スキーマを1つの<code>ObjectSchema</code>インスタンスに結合することで構築されます。</p>
+<p><code>ObjectSchema</code>インスタンスの<code>properties</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>に、対応する<code>PropertyAffordances</code>インスタンスの名前で識別される<code>PropertyAffordances</code>の各データスキーマが含まれている場合、これらのメタ相互作用ごとのデータスキーマは、各<code>PropertyAffordance</code>インスタンスのデータスキーマを1つの<code>ObjectSchema</code>インスタンスに結合することで構築される。</p>
 
-<p>(例えば、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>などにより)特に指定されていない場合、<code>readmultipleproperties</code>操作のリクエスト・データは、<code>Form</code>インスタンスで指定されているコンテンツ・タイプにシリアル化されている、意図された<code>PropertyAffordances</code>インスタンス名を含む<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>です。</p>
+<p>(例えば、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>などにより)特に指定されていない場合、<code>readmultipleproperties</code>操作のリクエストデータは、<code>Form</code>インスタンスで指定されているコンテンツタイプに<span class="mark">シリアライズ</span>されている、意図された<code>PropertyAffordances</code>インスタンス名を含む<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>である。</p>
 
 </section>
 <section id="interactionaffordance">
 
-<h5 id="x5-3-1-2-interactionaffordance"><bdi class="secno">5.3.1.2</bdi> <code>InteractionAffordance</code>(対話アフォーダンス)<a class="self-link" aria-label="§" href="#interactionaffordance"></a></h5>
+<h5 id="x5-3-1-2-interactionaffordance"><bdi class="secno">5.3.1.2</bdi> <code>InteractionAffordance</code><span class="mark">相互作用のアフォーダンス</span><a class="self-link" aria-label="§" href="#interactionaffordance"></a></h5>
 
-<p>可能な選択肢を<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>に提示するモノのメタデータで、これにより、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>がモノと対話を行える方法を提案します。潜在的なアフォーダンスには多くの種類がありますが、<abbr title="World Wide Web Consortium">W3C</abbr> WoTでは、プロパティー、アクション、イベントという3種類の対話アフォーダンスを定義しています。</p>
+<p>可能な選択肢を<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に提示する<span class="mark">Thing</span>のメタデータで、これにより、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>が<span class="mark">Thing</span>と相互作用を行える方法を提案する。潜在的なアフォーダンスには多くの種類があるが、<abbr title="World Wide Web Consortium">W3C</abbr> WoTでは、<span class="mark">Property</span>、<span class="mark">Action</span>、<span class="mark">Event</span>という3種類の<span class="mark">相互作用のアフォーダンス</span>を定義している。</p>
 
 <table class="def">
 <thead>
@@ -1716,50 +1722,50 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-at-type--InteractionAffordance">
     <td><code>@type</code></td>
-    <td>セマンティック・タグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
+    <td>セマンティックタグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-title--InteractionAffordance">
     <td><code>title</code></td>
-    <td>デフォルトの言語に基づいて、人間が読めるタイトルを提供します(例えば、UI表現用のテキストを表示)。</td>
+    <td>デフォルトの言語に基づいて、人間が読めるタイトルを提供する(例えば、UI表現用のテキストを表示)。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-titles--InteractionAffordance">
     <td><code>titles</code></td>
-    <td>多言語の人間が読めるタイトルを提供します(例えば、様々な言語でUI表現のテキストを表示)。</td>
+    <td>多言語の人間が読めるタイトルを提供する例えば、様々な言語でUI表現のテキストを表示)。</td>
     <td>オプション</td>
     <td><a href="#multilanguage"><code>MultiLanguage</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-description--InteractionAffordance">
     <td><code>description</code></td>
-    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供します。</td>
+    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--InteractionAffordance">
     <td><code>descriptions</code></td>
-    <td>様々な言語の(人間が読める)情報をサポートするために使用できます。</td>
+    <td>様々な言語の(人間が読める)情報をサポートするために使用できる。</td>
     <td>オプション</td>
     <td><a href="#multilanguage"><code>MultiLanguage</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-forms--InteractionAffordance">
     <td><code>forms</code></td>
-    <td>操作の実行方法を記述する、フォームのハイパーメディア制御の集合。フォームは、プロトコル・バインディングのシリアル化です。</td>
+    <td>操作の実行方法を記述する、フォームのハイパーメディア制御の集合。フォームは、プロトコルバインディングの<span class="mark">シリアライゼーション</span>である。</td>
     <td>必須</td>
     <td><a href="#form"><code>Form</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-uriVariables--InteractionAffordance">
     <td><code>uriVariables</code></td>
-    <td>DataSchema宣言に基づいて、URIテンプレート変数をコレクションとして定義します。</td>
+    <td>DataSchema宣言に基づいて、URIテンプレート変数をコレクションとして定義する。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a></td>
   </tr>
 </tbody>
 </table>
 
-<p><code>InteractionAffordance</code>というクラスには、次のサブクラスがあります。</p>
+<p><code>InteractionAffordance</code>というクラスには、次のサブクラスがある。</p>
 
 <ul>
   <li><a href="#propertyaffordance"><code>PropertyAffordance</code></a></li>
@@ -1770,9 +1776,9 @@
 </section>
 <section id="propertyaffordance">
 
-<h5 id="x5-3-1-3-propertyaffordance"><bdi class="secno">5.3.1.3</bdi> <code>PropertyAffordance</code>(プロパティー・アフォーダンス)<a class="self-link" aria-label="§" href="#propertyaffordance"></a></h5>
+<h5 id="x5-3-1-3-propertyaffordance"><bdi class="secno">5.3.1.3</bdi> <code>PropertyAffordance</code>(<span class="mark">Propertyの</span>アフォーダンス)<a class="self-link" aria-label="§" href="#propertyaffordance"></a></h5>
 
-<p>モノの状態を公開する対話アフォーダンス。この状態は、後で取得(読み取り)し、オプションで更新(書き込み)できます。モノは、変更後の新しい状態をプッシュすることにより、プロパティーを監視可能にすることも選択できます。</p>
+<p><span class="mark">Thing</span>の状態を公開する<span class="mark">相互作用のアフォーダンス</span>。この状態は、後で取得(読み取り)し、オプションで更新(書き込み)できる。<span class="mark">Thing</span>は、変更後の新しい状態をプッシュすることにより、<span class="mark">Property</span>を監視可能にすることも選択できる。</p>
 
 <table class="def">
 <thead>
@@ -1786,7 +1792,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance">
     <td><code>observable</code></td>
-    <td>モノと仲介を提供するサービエントが、このプロパティーの<code>observeproperty</code>操作をサポートするプロトコル・バインディングを提供すべきかどうかを示すヒント。</td>
+    <td><span class="mark">Thing</span>と<span class="mark">Intermediary</span>を提供する<span class="mark">Servient</span>が、この<span class="mark">Property</span>の<code>observeproperty</code>操作をサポートするプロトコルバインディングを提供すべきかどうかを示すヒント。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td>
   </tr>
@@ -1796,18 +1802,18 @@
 <div class="note" role="note" id="issue-container-generatedID">
 <div role="heading" class="note-title marker" id="h-note" aria-level="6"><span>注</span></div>
 
-<p class="">プロパティー・インスタンスは、<a href="#dataschema" class="sec-ref">DataSchema</a>というクラスのインスタンスでもあります。したがって、<code>type</code>、<code>unit</code>、<code>readOnly</code>、<code>writeOnly</code>などのメンバーを含めることができます。</p>
+<p class=""><span class="mark">Property</span>インスタンスは、<a href="#dataschema" class="sec-ref">DataSchema</a>というクラスのインスタンスでもある。したがって、<code>type</code>、<code>unit</code>、<code>readOnly</code>、<code>writeOnly</code>などのメンバーを含めることができる。</p>
 
 </div>
 
-<p><code>PropertyAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>と<code>DataSchema</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>です。<span class="rfc2119-assertion" id="td-op-for-property">Formインスタンスが<code>PropertyAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>readproperty</code>、<code>writeproperty</code>、<code>observeproperty</code>、<code>unobserveproperty</code>、またはこれらの用語の組み合わせを含でいる<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>のいずれかでなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>PropertyAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>と<code>DataSchema</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-property">Formインスタンスが<code>PropertyAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>readproperty</code>、<code>writeproperty</code>、<code>observeproperty</code>、<code>unobserveproperty</code>、またはこれらの用語の組み合わせを含でいる<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>のいずれかでなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 <section id="actionaffordance">
 
-<h5 id="x5-3-1-4-actionaffordance"><bdi class="secno">5.3.1.4</bdi> <code>ActionAffordance</code>(アクション・アフォーダンス)<a class="self-link" aria-label="§" href="#actionaffordance"></a></h5>
+<h5 id="x5-3-1-4-actionaffordance"><bdi class="secno">5.3.1.4</bdi> <code>ActionAffordance</code>(<span class="mark">Actionの</span>アフォーダンス)<a class="self-link" aria-label="§" href="#actionaffordance"></a></h5>
 
-<p>状態を操作したり(例えば、照明のオン/オフを切り替える)、モノにおけるプロセスを始動させる(例えば、時間の経過とともに照明を暗くする)といった、モノの機能の呼び出しを可能にする対話アフォーダンス。</p>
+<p>状態を操作したり(例えば、照明のオン/オフを切り替える)、<span class="mark">Thing</span>におけるプロセスを始動させる(例えば、時間の経過とともに照明を暗くする)といった、<span class="mark">Thing</span>の機能の呼び出しを可能にする<span class="mark">相互作用のアフォーダンス</span>。</p>
 
 <table class="def">
 <thead>
@@ -1821,39 +1827,39 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-input--ActionAffordance">
     <td><code>input</code></td>
-    <td>アクションの入力データ・スキーマを定義するために用います。</td>
+    <td><span class="mark">Action</span>の入力データスキーマを定義するために用いる。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-output--ActionAffordance">
     <td><code>output</code></td>
-    <td>アクションの出力データ・スキーマを定義するために用います。</td>
+    <td><span class="mark">Action</span>の出力データスキーマを定義するために用いる。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-safe--ActionAffordance">
     <td><code>safe</code></td>
-    <td>アクションが安全か(=true)否かを通知します。アクションを呼び出す際に、内部状態(資源の状態を参照)が変更されていないかを通知するために用います。その場合、例として応答をキャッシュできます。</td>
+    <td><span class="mark">Action</span>が安全か(=true)否かを通知する。<span class="mark">Action</span>を呼び出す際に、内部状態(資源の状態を参照)が変更されていないかを通知するために用いる。その場合、例として応答をキャッシュできる。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-idempotent--ActionAffordance">
     <td><code>idempotent</code></td>
-    <td>アクションが冪等か(=true)否かを示します。同じ入力に基づいて、結果が同じであるアクション(存在している場合)を繰り返し呼び出すことができるかどうかを通知します。</td>
+    <td><span class="mark">Action</span>が冪等か(=true)否かを示す。同じ入力に基づいて、結果が同じである<span class="mark">Action</span>(存在している場合)を繰り返し呼び出すことができるかどうかを通知する。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td>
   </tr>
 </tbody>
 </table>
 
-<p><code>ActionAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>です。<span class="rfc2119-assertion" id="td-op-for-action">Formインスタンスが<code>ActionAffordance</code>インスタンス内にある場合、opに割り当てられている値は、<code>invokeaction</code>でなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>ActionAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-action">Formインスタンスが<code>ActionAffordance</code>インスタンス内にある場合、opに割り当てられている値は、<code>invokeaction</code>でなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 <section id="eventaffordance">
 
-<h5 id="x5-3-1-5-eventaffordance"><bdi class="secno">5.3.1.5</bdi> <code>EventAffordance</code>(イベント・アフォーダンス)<a class="self-link" aria-label="§" href="#eventaffordance"></a></h5>
+<h5 id="x5-3-1-5-eventaffordance"><bdi class="secno">5.3.1.5</bdi> <code>EventAffordance</code>(<span class="mark">Eventの</span>アフォーダンス)<a class="self-link" aria-label="§" href="#eventaffordance"></a></h5>
 
-<p>イベント(例えば、オーバーヒートの警報)の情報源を記述している対話アフォーダンスで、イベント・データを<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>に非同期でプッシュします。</p>
+<p><span class="mark">出来事</span>(例えば、オーバーヒートの警報)の情報源を記述している<span class="mark">相互作用のアフォーダンス</span>で、<span class="mark">出来事</span>データを<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に非同期でプッシュする。</p>
 
 <table class="def">
 <thead>
@@ -1867,33 +1873,33 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-subscription--EventAffordance">
     <td><code>subscription</code></td>
-    <td>購読時に渡す必要があるデータ(例えば、Webhookを設定するためのフィルターやメッセージ形式)を定義します。</td>
+    <td><span class="mark">登録</span>時に渡す必要があるデータ(例えば、Webhookを設定するためのフィルターやメッセージ形式)を定義する。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-data--EventAffordance">
     <td><code>data</code></td>
-    <td>モノがプッシュするイベントのインスタンス・メッセージのデータ・スキーマを定義します。</td>
+    <td><span class="mark">Thing</span>がプッシュする<span class="mark">Event</span>のインスタンスメッセージのデータスキーマを定義する。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-cancellation--EventAffordance">
     <td><code>cancellation</code></td>
-    <td>購読を中止するために渡す必要があるデータ(例えば、Webhookを削除するための特定のメッセージ)を定義します。</td>
+    <td><span class="mark">登録</span>を中止するために渡す必要があるデータ(例えば、Webhookを削除するための特定のメッセージ)を定義する。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a></td>
   </tr>
 </tbody>
 </table>
 
-<p><code>EventAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>です。<span class="rfc2119-assertion" id="td-op-for-event">Formインスタンスが<code>EventAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>subscribeevent</code>、<code>unsubscribeevent</code>、または<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内の両方の用語のいずれかでなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>EventAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-event">Formインスタンスが<code>EventAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>subscribeevent</code>、<code>unsubscribeevent</code>、または<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内の両方の用語のいずれかでなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 <section id="versioninfo">
 
 <h5 id="x5-3-1-6-versioninfo"><bdi class="secno">5.3.1.6</bdi> <code>VersionInfo</code>(バージョン情報)<a class="self-link" aria-label="§" href="#versioninfo"></a></h5>
 
-<p>TDドキュメントに関するバージョン情報を提供するモノのメタデータ。必要に応じて、ファームウェアやハードウェアのバージョン(TD名前空間外の用語定義)などの付加的なバージョン情報を<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のメカニズムを介して拡張できます。</p>
+<p>TDドキュメントに関するバージョン情報を提供する<span class="mark">Thing</span>のメタデータ。必要に応じて、ファームウェアやハードウェアのバージョン(TD名前空間外の用語定義)などの付加的なバージョン情報を<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のメカニズムを介して拡張できる。</p>
 
 <table class="def">
 <thead>
@@ -1907,39 +1913,39 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-instance--VersionInfo">
     <td><code>instance</code></td>
-    <td>このTDのインスタンスのバージョン表示を提供します。</td>
+    <td>このTDのインスタンスのバージョン表示を提供する。</td>
     <td>必須</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
 </tbody>
 </table>
 
-<p><code>VersionInfo</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の値は、ドットで区切られた3つの数字の列がそれぞれメジャー・バージョン、マイナー・バージョン、パッチ・バージョンを示す、セマンティック・バージョニングのパターンに従うことをお勧めします。詳細に関しては、[<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>]を参照してください。</p>
+<p><code>VersionInfo</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の値は、ドットで区切られた3つの数字の列がそれぞれメジャーバージョン、マイナーバージョン、パッチバージョンを示す、セマンティックバージョニングのパターンに従うことをお勧めする。詳細に関しては、[<cite><a class="bibref" data-link-type="biblio" href="#bib-semver" title="Semantic Versioning 2.0.0">SEMVER</a></cite>]を参照していただきたい。</p>
 
 </section>
 <section id="multilanguage">
 
 <h5 id="x5-3-1-7-multilanguage"><bdi class="secno">5.3.1.7</bdi> <code>MultiLanguage</code>(多言語)<a class="self-link" aria-label="§" href="#multilanguage"></a></h5>
 
-<p>[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で記述されている言語タグによって識別される様々な言語の人間が読めるテキストの集合を提供する<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>。モノの記述のインスタンスにおけるこのコンテナの使用例については、<a href="#titles-descriptions-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.2</bdi> 人間が読めるメタデータ</a>を参照してください。</p>
+<p>[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で記述されている言語タグによって識別される様々な言語の人間が読めるテキストの集合を提供する<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>。<span class="mark">Thing Description</span>のインスタンスにおけるこのコンテナの使用例については、<a href="#titles-descriptions-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.2</bdi> 人間が読めるメタデータ</a>を参照していただきたい。</p>
 
-<p><span class="rfc2119-assertion" id="td-multilanguage-language-tag"><code>MultiLanguage</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のそれぞれの名前は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で定義されている言語タグでなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-multilanguage-value"><code>MultiLanguage</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のそれぞれの値は、<code>string</code>型でなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-multilanguage-language-tag"><code>MultiLanguage</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のそれぞれの名前は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で定義されている言語タグでなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-multilanguage-value"><code>MultiLanguage</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のそれぞれの値は、<code>string</code>型でなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 </section>
 <section id="sec-data-schema-vocabulary-definition">
 
-<h4 id="x5-3-2-data-schema-vocabulary-definitions"><bdi class="secno">5.3.2</bdi> データ・スキーマ語彙の定義<a class="self-link" aria-label="§" href="#sec-data-schema-vocabulary-definition"></a></h4>
+<h4 id="x5-3-2-data-schema-vocabulary-definitions"><bdi class="secno">5.3.2</bdi> <span class="mark">Data Schema</span>語彙の定義<a class="self-link" aria-label="§" href="#sec-data-schema-vocabulary-definition"></a></h4>
 
-<p>データ・スキーマ語彙定義は、JSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている用語の非常に一般的なサブセットを反映したものです。モノの記述のインスタンス内のデータ・スキーマ定義はこの定義済みのサブセットに限定されず、<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>で記述しているとおり、追加の用語に<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテンツ拡張</a>を用いて、JSONスキーマにある追加の用語を使用でき、そうでない場合は、これらの用語は、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>によってセマンティック的に無視されることに注意が必要です。(セマンティックな処理の詳細に関しては、<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> JSON-LDコンテキストの使用法</a>や、<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下のドキュメントを参照してください)。</p>
+<p>データスキーマ語彙定義は、JSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている用語の非常に一般的なサブセットを反映したものである。<span class="mark">Thing Description</span>のインスタンス内のデータスキーマ定義はこの定義済みのサブセットに限定されず、<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>で記述しているとおり、追加の用語に<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテンツ拡張</a>を用いて、JSONスキーマにある追加の用語を使用でき、そうでない場合は、これらの用語は、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>によってセマンティック的に無視されることに注意が必要である。(セマンティックな処理の詳細に関しては、<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> JSON-LDコンテキストの使用法</a>や、<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下のドキュメントを参照)。</p>
 
-<p>データ・スキーマは、データ形式に含まれるデータの抽象的な表記法です。TDでは、具体的なデータ形式は、コンテンツ・タイプを用いてForm(<a href="#form" class="sec-ref">§&nbsp;<bdi class="secno">5.3.4.2</bdi> <code>Form</code>(フォーム)</a>を参照)で指定されます。Formのインスタンス内のコンテンツ・タイプの値が<code>application/json</code>であれば、JSONスキーマ・プロセッサでデータ・スキーマを直接処理できます。そうでない場合は、モノのウェブ(WoT)バインディング・テンプレート[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]は、XML[<cite><a class="bibref" data-link-type="biblio" href="#bib-xml" title="Extensible Markup Language (XML) 1.0 (Fifth Edition)">xml</a></cite>]などの他のコンテンツ・タイプへのデータ・スキーマの利用可能なマッピングを定義します。フォームのインスタンス内のコンテンツ・タイプが<code>application/json</code>でなく、コンテンツ・タイプにマッピングが定義されていない場合は、データ・スキーマを指定してもコンテンツ・タイプには意味がありません。</p>
+<p>データスキーマは、データ形式に含まれるデータの抽象的な表記法である。TDでは、具体的なデータ形式は、コンテンツタイプを用いてForm(<a href="#form" class="sec-ref">§&nbsp;<bdi class="secno">5.3.4.2</bdi> <code>Form</code>(フォーム)</a>を参照)で指定される。Formのインスタンス内のコンテンツタイプの値が<code>application/json</code>であれば、JSONスキーマプロセッサでデータスキーマを直接処理できる。そうでない場合は、<span class="mark">Web of Things</span> (WoT) バインディングテンプレート[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]は、XML[<cite><a class="bibref" data-link-type="biblio" href="#bib-xml" title="Extensible Markup Language (XML) 1.0 (Fifth Edition)">xml</a></cite>]などの他のコンテンツタイプへのデータスキーマの利用可能なマッピングを定義する。フォームのインスタンス内のコンテンツタイプが<code>application/json</code>でなく、コンテンツタイプにマッピングが定義されていない場合は、データスキーマを指定してもコンテンツタイプには意味がない。</p>
 
 <section id="dataschema">
 
-<h5 id="x5-3-2-1-dataschema"><bdi class="secno">5.3.2.1</bdi> <code>DataSchema</code>(データ・スキーマ)<a class="self-link" aria-label="§" href="#dataschema"></a></h5>
+<h5 id="x5-3-2-1-dataschema"><bdi class="secno">5.3.2.1</bdi> <code>DataSchema</code><a class="self-link" aria-label="§" href="#dataschema"></a></h5>
 
-<p>用いているデータ形式を記述するメタデータ。検証に使用できます。</p>
+<p>用いているデータ形式を記述するメタデータ。検証に使用できる。</p>
 
 <table class="def">
 <thead>
@@ -1953,31 +1959,31 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-at-type--DataSchema">
     <td><code>@type</code></td>
-    <td>セマンティック・タグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
+    <td>セマンティックタグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-title--DataSchema">
     <td><code>title</code></td>
-    <td>デフォルトの言語に基づいて、人間が読めるタイトルを提供します(例えば、UI表現用のテキストを表示)。</td>
+    <td>デフォルトの言語に基づいて、人間が読めるタイトルを提供する(例えば、UI表現用のテキストを表示)。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-titles--DataSchema">
     <td><code>titles</code></td>
-    <td>多言語の人間が読めるタイトルを提供します(例えば、様々な言語でUI表現のテキストを表示)。</td>
+    <td>多言語の人間が読めるタイトルを提供する(例えば、様々な言語でUI表現のテキストを表示)。</td>
     <td>オプション</td>
     <td><a href="#multilanguage"><code>MultiLanguage</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-description--DataSchema">
     <td><code>description</code></td>
-    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供します。</td>
+    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--DataSchema">
     <td><code>descriptions</code></td>
-    <td>様々な言語の(人間が読める)情報をサポートするために使用できます。</td>
+    <td>様々な言語の(人間が読める)情報をサポートするために使用する。</td>
     <td>オプション</td>
     <td><a href="#multilanguage"><code>MultiLanguage</code></a></td>
   </tr>
@@ -1989,19 +1995,19 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-const--DataSchema">
     <td><code>const</code></td>
-    <td>定数値を提供します。</td>
+    <td>定数値を提供する。</td>
     <td>オプション</td>
     <td>任意の型</td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-unit--DataSchema">
     <td><code>unit</code></td>
-    <td>例えば、国際的な科学、工学、ビジネスなどで用いられている単位情報を提供します。</td>
+    <td>例えば、国際的な科学、工学、ビジネスなどで用いられている単位情報を提供する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-oneOf--DataSchema">
     <td><code>oneOf</code></td>
-    <td>配列内の指定されたスキーマの1つに対してデータが有効であることを保証するために用います。</td>
+    <td>配列内の指定されたスキーマの1つに対してデータが有効であることを保証するために用いる。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
@@ -2013,26 +2019,26 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-readOnly--DataSchema">
     <td><code>readOnly</code></td>
-    <td>プロパティーの対話/値が読み取り専用か(=true)否か(=false)を示すヒントであるブール値。</td>
+    <td>プロパティーの相互作用/値が読み取り専用か(=true)否か(=false)を示すヒントであるブール値。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-writeOnly--DataSchema">
     <td><code>writeOnly</code></td>
-    <td>プロパティーの対話/値が書き込み専用か(=true)否か(=false)を示すヒントであるブール値。</td>
+    <td>プロパティーの相互作用/値が書き込み専用か(=true)否か(=false)を示すヒントであるブール値。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-format--DataSchema">
     <td><code>format</code></td>
-    <td>「date-time」、「email」、「uri」などの形式パターンに基づく検証を可能にします(以下も参照)。</td>
+    <td>「date-time」、「email」、「uri」などの形式パターンに基づく検証を可能にする(以下も参照)。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
 </tbody>
 </table>
 
-<p><code>DataSchema</code>というクラスには、次のサブクラスがあります。</p>
+<p><code>DataSchema</code>というクラスには、次のサブクラスがある。</p>
 
 <ul>
   <li><a href="#arrayschema"><code>ArraySchema</code></a></li>
@@ -2044,14 +2050,14 @@
   <li><a href="#nullschema"><code>NullSchema</code></a></li>
 </ul>
 
-<p><code>format</code>の文字列の値は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>](特に、7.3 定義フォーマット)で定義されている固定値の集合とその対応するフォーマットの規則から判別されます。<span class="rfc2119-assertion" id="td-format-validation-known-values">サービエントは、<code>format</code>の値を用いて、それに応じた追加の検証を実行できます(<em class="rfc2119" title="MAY">MAY</em>)</span>。<span class="rfc2119-assertion" id="td-format-validation-other-values">既知の値の集合にない値が<code>format</code>に割り当てられていれば、そのような検証は成功すべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
+<p><code>format</code>の文字列の値は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>](特に、7.3 定義フォーマット)で定義されている固定値の集合とその対応するフォーマットの規則から判別される。<span class="rfc2119-assertion" id="td-format-validation-known-values"><span class="mark">Servient</span>は、<code>format</code>の値を用いて、それに応じた追加の検証を実行できる(<em class="rfc2119" title="MAY">MAY</em>)</span>。<span class="rfc2119-assertion" id="td-format-validation-other-values">既知の値の集合にない値が<code>format</code>に割り当てられていれば、そのような検証は成功すべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
 
 </section>
 <section id="arrayschema">
 
 <h5 id="x5-3-2-2-arrayschema"><bdi class="secno">5.3.2.2</bdi> <code>ArraySchema</code>(配列スキーマ)<a class="self-link" aria-label="§" href="#arrayschema"></a></h5>
 
-<p><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>array</code>という値で示されます。</p>
+<p><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>array</code>という値で示される。</p>
 
 <table class="def">
 <thead>
@@ -2065,19 +2071,19 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema">
     <td><code>items</code></td>
-    <td>配列の特性を定義するために用います。</td>
+    <td>配列の特性を定義するために用いる。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a>または<a href="#dataschema"><code>DataSchema</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema">
     <td><code>minItems</code></td>
-    <td>配列内になくてはならないアイテムの最小の数を定義します。</td>
+    <td>配列内になくてはならないアイテムの最小の数を定義する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema">
     <td><code>maxItems</code></td>
-    <td>配列内になくてはならないアイテムの最大の数を定義します。</td>
+    <td>配列内になくてはならないアイテムの最大の数を定義する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td>
   </tr>
@@ -2087,16 +2093,16 @@
 </section>
 <section id="booleanschema">
 
-<h5 id="x5-3-2-3-booleanschema"><bdi class="secno">5.3.2.3</bdi> <code>BooleanSchema</code>(ブール・スキーマ)<a class="self-link" aria-label="§" href="#booleanschema"></a></h5>
+<h5 id="x5-3-2-3-booleanschema"><bdi class="secno">5.3.2.3</bdi> <code>BooleanSchema</code>(ブールスキーマ)<a class="self-link" aria-label="§" href="#booleanschema"></a></h5>
 
-<p><code>boolean</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>boolean</code>という値で示されます。</p>
+<p><code>boolean</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>boolean</code>という値で示される。</p>
 
 </section>
 <section id="numberschema">
 
 <h5 id="x5-3-2-4-numberschema"><bdi class="secno">5.3.2.4</bdi> <code>NumberSchema</code>(数値スキーマ)<a class="self-link" aria-label="§" href="#numberschema"></a></h5>
 
-<p><code>number</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>number</code>という値で示されます。</p>
+<p><code>number</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>number</code>という値で示される。</p>
 
 <table class="def">
 <thead>
@@ -2110,13 +2116,13 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-minimum--NumberSchema">
     <td><code>minimum</code></td>
-    <td>最小の数の値を指定します。関連する数値または整数の型にのみ適用されます。</td>
+    <td>最小の数の値を指定する。関連する数値または整数の型にのみ適用される。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-maximum--NumberSchema">
     <td><code>maximum</code></td>
-    <td>最大の数の値を指定します。関連する数値または整数の型にのみ適用されます。</td>
+    <td>最大の数の値を指定する。関連する数値または整数の型にのみ適用される。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#double"><code>double</code></a></td>
   </tr>
@@ -2128,7 +2134,7 @@
 
 <h5 id="x5-3-2-5-integerschema"><bdi class="secno">5.3.2.5</bdi> <code>IntegerSchema</code>(整数スキーマ)<a class="self-link" aria-label="§" href="#integerschema"></a></h5>
 
-<p><code>integer</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>integer</code>という値で示されます。</p>
+<p><code>integer</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>integer</code>という値で示される。</p>
 
 <table class="def">
 <thead>
@@ -2142,13 +2148,13 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-minimum--IntegerSchema">
     <td><code>minimum</code></td>
-    <td>最小の数の値を指定します。関連する数値または整数の型にのみ適用されます。</td>
+    <td>最小の数の値を指定する。関連する数値または整数の型にのみ適用される。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-maximum--IntegerSchema">
     <td><code>maximum</code></td>
-    <td>最大の数の値を指定します。関連する数値または整数の型にのみ適用されます。</td>
+    <td>最大の数の値を指定する。関連する数値または整数の型にのみ適用される。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#integer"><code>integer</code></a></td>
   </tr>
@@ -2158,9 +2164,9 @@
 </section>
 <section id="objectschema">
 
-<h5 id="x5-3-2-6-objectschema"><bdi class="secno">5.3.2.6</bdi> <code>ObjectSchema</code>(オブジェクト・スキーマ)<a class="self-link" aria-label="§" href="#objectschema"></a></h5>
+<h5 id="x5-3-2-6-objectschema"><bdi class="secno">5.3.2.6</bdi> <code>ObjectSchema</code>(オブジェクトスキーマ)<a class="self-link" aria-label="§" href="#objectschema"></a></h5>
 
-<p><code>object</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>object</code>という値で示されます。</p>
+<p><code>object</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>object</code>という値で示される。</p>
 
 <table class="def">
 <thead>
@@ -2174,13 +2180,13 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema">
     <td><code>properties</code></td>
-    <td>データ・スキーマの入れ子の定義。</td>
+    <td>データスキーマの入れ子の定義。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-required--ObjectSchema">
     <td><code>required</code></td>
-    <td>オブジェクト型のどのメンバーが必須かを定義します。</td>
+    <td>オブジェクト型のどのメンバーが必須かを定義する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
@@ -2192,14 +2198,14 @@
 
 <h5 id="x5-3-2-7-stringschema"><bdi class="secno">5.3.2.7</bdi> <code>StringSchema</code>(文字列スキーマ)<a class="self-link" aria-label="§" href="#stringschema"></a></h5>
 
-<p><code>string</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>string</code>という値で示されます。</p>
+<p><code>string</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>string</code>という値で示される。</p>
 
 </section>
 <section id="nullschema">
 
 <h5 id="x5-3-2-8-nullschema"><bdi class="secno">5.3.2.8</bdi> <code>NullSchema</code>(ヌル(Null)スキーマ)<a class="self-link" aria-label="§" href="#nullschema"></a></h5>
 
-<p><code>null</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>null</code>という値で示されます。このサブクラスは、1つの許容値、つまり<code>null</code>のみを記述します。これは<code>oneOf</code>宣言の一部として使用でき、その場合、データが<code>null</code>にもなりえることを示すために用います。</p>
+<p><code>null</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>null</code>という値で示される。このサブクラスは、1つの許容値、つまり<code>null</code>のみを記述する。これは<code>oneOf</code>宣言の一部として使用でき、その場合、データが<code>null</code>にもなりえることを示すために用いる。</p>
 
 </section>
 </section>
@@ -2207,13 +2213,13 @@
 
 <h4 id="x5-3-3-security-vocabulary-definitions"><bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義<a class="self-link" aria-label="§" href="#sec-security-vocabulary-definition"></a></h4>
 
-<p>この仕様は、<abbr title="World Wide Web Consortium">W3C</abbr> WoTの<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>として適しているプロトコルに直接組み込まれる、またはそのプロトコルで広く用いられる、確立されたセキュリティ・メカニズムの選択について規定しています。現在のHTTPセキュリティ・スキームは、部分的に<a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject">OpenAPI 3.0.1</a>に基づいています([<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification: Version 3.0.1">OPENAPI</a></cite>]も参照)。しかし、この仕様で示しているHTTPセキュリティ・スキーム、<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>、および構文は、OpenAPIと多くの類似点を共有しているものの、互換性はありません。</p>
+<p>この仕様は、<abbr title="World Wide Web Consortium">W3C</abbr> WoTの<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>として適しているプロトコルに直接組み込まれる、またはそのプロトコルで広く用いられる、確立されたセキュリティメカニズムの選択について規定している。現在のHTTPセキュリティスキームは、部分的に<a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject">OpenAPI 3.0.1</a>に基づいている([<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification: Version 3.0.1">OPENAPI</a></cite>]も参照)。しかし、この仕様で示しているHTTPセキュリティスキーム、<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>、および構文は、OpenAPIと多くの類似点を共有しているものの、互換性はない。</p>
 
 <section id="securityscheme">
 
-<h5 id="x5-3-3-1-securityscheme"><bdi class="secno">5.3.3.1</bdi> <code>SecurityScheme</code>(セキュリティ・スキーム)<a class="self-link" aria-label="§" href="#securityscheme"></a></h5>
+<h5 id="x5-3-3-1-securityscheme"><bdi class="secno">5.3.3.1</bdi> <code>SecurityScheme</code>(セキュリティスキーム)<a class="self-link" aria-label="§" href="#securityscheme"></a></h5>
 
-<p>セキュリティ・メカニズムの設定を記述するメタデータ。<span class="rfc2119-assertion" id="td-security-scheme-name"><code>scheme</code>という名前に割り当てられる値は、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で定義している標準的な<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>か<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のいずれかで、<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>に含まれている<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>内で定義しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p>セキュリティメカニズムの<span class="mark">構成</span>を記述するメタデータ。<span class="rfc2119-assertion" id="td-security-scheme-name"><code>scheme</code>という名前に割り当てられる値は、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で定義している標準的な<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>か<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のいずれかで、<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>に含まれている<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>内で定義しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 <table class="def">
 <thead>
@@ -2227,38 +2233,38 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-at-type--SecurityScheme">
     <td><code>@type</code></td>
-    <td>セマンティック・タグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
+    <td>セマンティックタグ(または型)でオブジェクトをラベル付けするJSON-LDキーワード。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-scheme--SecurityScheme">
     <td><code>scheme</code></td>
-    <td>設定されているセキュリティ・メカニズムの識別。</td>
+    <td>設定されているセキュリティメカニズムの識別。</td>
     <td>必須</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(例えば、<code>nosec</code>、<code>basic</code>、<code>digest</code>、<code>bearer</code>、<code>psk</code>, <code>oauth2</code>、または<code>apikey</code>)</td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-description--SecurityScheme">
     <td><code>description</code></td>
-    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供します。</td>
+    <td>デフォルト言語に基づいて、追加の(人間が読める)情報を提供するす。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-descriptions--SecurityScheme">
     <td><code>descriptions</code></td>
-    <td>様々な言語の(人間が読める)情報をサポートするために使用できます。</td>
+    <td>様々な言語の(人間が読める)情報をサポートするために使用できる。</td>
     <td>オプション</td>
     <td><a href="#multilanguage"><code>MultiLanguage</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-proxy--SecurityScheme">
     <td><code>proxy</code></td>
-    <td>このセキュリティ設定がアクセスを提供するプロキシ・サーバーのURI。指定されていない場合、対応するセキュリティ設定はエンドポイント用です。</td>
+    <td>このセキュリティ<span class="mark">構成情報</span>がアクセスを提供するプロキシサーバーのURI。指定されていない場合、対応するセキュリティ<span class="mark">構成情報</span>はエンドポイント用である。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
 </tbody>
 </table>
 
-<p><code>SecurityScheme</code>というクラスには次のサブクラスがあります。</p>
+<p><code>SecurityScheme</code>というクラスには次のサブクラスがある。</p>
 
 <ul>
   <li><a href="#nosecurityscheme"><code>NoSecurityScheme</code></a></li>
@@ -2273,16 +2279,16 @@
 </section>
 <section id="nosecurityscheme">
 
-<h5 id="x5-3-3-2-nosecurityscheme"><bdi class="secno">5.3.3.2</bdi> <code>NoSecurityScheme</code>(セキュリティ・スキームなし)<a class="self-link" aria-label="§" href="#nosecurityscheme"></a></h5>
+<h5 id="x5-3-3-2-nosecurityscheme"><bdi class="secno">5.3.3.2</bdi> <code>NoSecurityScheme</code>(セキュリティスキームなし)<a class="self-link" aria-label="§" href="#nosecurityscheme"></a></h5>
 
-<p><code>nosec</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるセキュリティ設定(つまり、<code>"scheme": "nosec"</code>)で、資源へのアクセスに認証やその他のメカニズムが必要ないことを示します。</p>
+<p><code>nosec</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるセキュリティ<span class="mark">構成情報</span>(つまり、<code>"scheme": "nosec"</code>)で、資源へのアクセスに認証やその他のメカニズムが必要ないことを示す。</p>
 
 </section>
 <section id="basicsecurityscheme">
 
-<h5 id="x5-3-3-3-basicsecurityscheme"><bdi class="secno">5.3.3.3</bdi> <code>BasicSecurityScheme</code>(基本セキュリティ・スキーム)<a class="self-link" aria-label="§" href="#basicsecurityscheme"></a></h5>
+<h5 id="x5-3-3-3-basicsecurityscheme"><bdi class="secno">5.3.3.3</bdi> <code>BasicSecurityScheme</code>(基本セキュリティスキーム)<a class="self-link" aria-label="§" href="#basicsecurityscheme"></a></h5>
 
-<p><code>basic</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別される基本認証[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>]セキュリティ設定(つまり、<code>"scheme": "basic"</code>)で、暗号化されていないユーザ名とパスワードを用います。このスキームは、例えば、TLSなどの機密性を提供する他のセキュリティ・メカニズムとともに用いるべきです。</p>
+<p><code>basic</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別される基本認証[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>]セキュリティ<span class="mark">構成情報</span>(つまり、<code>"scheme": "basic"</code>)で、暗号化されていないユーザ名とパスワードを用いる。このスキームは、例えば、TLSなどの機密性を提供する他のセキュリティメカニズムとともに用いるべきである。</p>
 
 <table class="def">
 <thead>
@@ -2296,7 +2302,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-in--BasicSecurityScheme">
     <td><code>in</code></td>
-    <td>セキュリティ認証情報の場所を指定します。</td>
+    <td>セキュリティ認証情報の場所を指定する。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(<code>header</code>、<code>query</code>、<code>body</code>、<code>cookie</code>のうちの1つ)</td>
   </tr>
@@ -2312,9 +2318,9 @@
 </section>
 <section id="digestsecurityscheme">
 
-<h5 id="x5-3-3-4-digestsecurityscheme"><bdi class="secno">5.3.3.4</bdi> <code>DigestSecurityScheme</code>(ダイジェスト・セキュリティ・スキーム)<a class="self-link" aria-label="§" href="#digestsecurityscheme"></a></h5>
+<h5 id="x5-3-3-4-digestsecurityscheme"><bdi class="secno">5.3.3.4</bdi> <code>DigestSecurityScheme</code>(ダイジェストセキュリティスキーム)<a class="self-link" aria-label="§" href="#digestsecurityscheme"></a></h5>
 
-<p><code>digest</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるダイジェスト・アクセス認証[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]セキュリティ設定(つまり、<code>"scheme": "digest"</code>)。このスキームは基本認証に似ていますが、中間者攻撃(man-in-the-middle attack)を回避する機能が追加されています。</p>
+<p><code>digest</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるダイジェストアクセス認証[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7616" title="HTTP Digest Access Authentication">RFC7616</a></cite>]セキュリティ<span class="mark">構成情報</span>(つまり、<code>"scheme": "digest"</code>)。このスキームは基本認証に似ているが、中間者攻撃(man-in-the-middle attack)を回避する機能が追加されている。</p>
 
 <table class="def">
 <thead>
@@ -2334,7 +2340,7 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-in--DigestSecurityScheme">
     <td><code>in</code></td>
-    <td>セキュリティ認証情報の場所を指定します。</td>
+    <td>セキュリティ認証情報の場所を指定する。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(<code>header</code>、<code>query</code>、<code>body</code>、<code>cookie</code>のうちの1つ)</td>
   </tr>
@@ -2342,8 +2348,7 @@
     <td><code>name</code></td>
     <td>クエリ、ヘッダー、またはクッキーのパラメータの名前。</td>
     <td>オプション</td>
-    <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string">
-                  <code>string</code></a></td>
+    <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
 </tbody>
 </table>
@@ -2351,9 +2356,9 @@
 </section>
 <section id="apikeysecurityscheme">
 
-<h5 id="x5-3-3-5-apikeysecurityscheme"><bdi class="secno">5.3.3.5</bdi> <code>APIKeySecurityScheme</code>(APIキー・セキュリティ・スキーム)<a class="self-link" aria-label="§" href="#apikeysecurityscheme"></a></h5>
+<h5 id="x5-3-3-5-apikeysecurityscheme"><bdi class="secno">5.3.3.5</bdi> <code>APIKeySecurityScheme</code>(APIキーセキュリティスキーム)<a class="self-link" aria-label="§" href="#apikeysecurityscheme"></a></h5>
 
-<p><code>apikey</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるAPIキー認証セキュリティ設定(つまり、<code>"scheme": "apikey"</code>)。これは、アクセス・トークンが不透明で、標準的なトークン形式を用いていない場合です。</p>
+<p><code>apikey</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるAPIキー認証セキュリティ<span class="mark">構成情報</span>(つまり、<code>"scheme": "apikey"</code>)。これは、アクセストークンが不透明で、標準的なトークン形式を用いていない場合である。</p>
 
 <table class="def">
 <thead>
@@ -2367,7 +2372,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-in--APIKeySecurityScheme">
     <td><code>in</code></td>
-    <td>セキュリティ認証情報の場所を指定します。</td>
+    <td>セキュリティ認証情報の場所を指定する。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(<code>header</code>、<code>query</code>、<code>body</code>、<code>cookie</code>のうちの1つ)</td>
   </tr>
@@ -2383,9 +2388,9 @@
 </section>
 <section id="bearersecurityscheme">
 
-<h5 id="x5-3-3-6-bearersecurityscheme"><bdi class="secno">5.3.3.6</bdi> <code>BearerSecurityScheme</code>(ベアラー・セキュリティー・スキーム)<a class="self-link" aria-label="§" href="#bearersecurityscheme"></a></h5>
+<h5 id="x5-3-3-6-bearersecurityscheme"><bdi class="secno">5.3.3.6</bdi> <code>BearerSecurityScheme</code>(ベアラーセキュリティースキーム)<a class="self-link" aria-label="§" href="#bearersecurityscheme"></a></h5>
 
-<p>ベアラー・トークンがOAuth2と関わりなく用いられる状況のために、<code>bearer</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるベアラー・トークン[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]セキュリティ設定(つまり、<code>"scheme": "bearer"</code>)。<code>oauth2</code>スキームが指定されている場合は、一般的に、このスキームを指定する必要はなく、暗黙的に指定されています。<code>format</code>では、<code>jwt</code>という値は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>]との適合性を示し、<code>jws</code>は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7797" title="JSON Web Signature (JWS) Unencoded Payload Option">RFC7797</a></cite>]との適合性を示し、<code>cwt</code>は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>]との適合性を示し、<code>jwe</code>は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>]との適合性を示し、<code>alg</code>の値をこれらの標準と整合的に解釈します。<span class="rfc2119-assertion" id="td-security-bearer-format-extensions">ベアラー・トークンのその他の形式とアルゴリズムは、語彙拡張で指定できます(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
+<p>ベアラートークンがOAuth2と関わりなく用いられる状況のために、<code>bearer</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるベアラートークン[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6750" title="The OAuth 2.0 Authorization Framework: Bearer Token Usage">RFC6750</a></cite>]セキュリティ<span class="mark">構成情報</span>(つまり、<code>"scheme": "bearer"</code>)。<code>oauth2</code>スキームが指定されている場合は、一般的に、このスキームを指定する必要はなく、暗黙的に指定されている。<code>format</code>では、<code>jwt</code>という値は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>]との適合性を示し、<code>jws</code>は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7797" title="JSON Web Signature (JWS) Unencoded Payload Option">RFC7797</a></cite>]との適合性を示し、<code>cwt</code>は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>]との適合性を示し、<code>jwe</code>は[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>]との適合性を示し、<code>alg</code>の値をこれらの標準と整合的に解釈する。<span class="rfc2119-assertion" id="td-security-bearer-format-extensions">ベアラートークンのその他の形式とアルゴリズムは、語彙拡張で指定できる(<em class="rfc2119" title="MAY">MAY</em>)。</span></p>
 
 <table class="def">
 <thead>
@@ -2399,25 +2404,25 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-authorization--BearerSecurityScheme">
     <td><code>authorization</code></td>
-    <td>承認サーバーのURI。</td>
+    <td><span class="mark">認可</span>サーバーのURI。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-alg--BearerSecurityScheme">
     <td><code>alg</code></td>
-    <td>エンコーディング、暗号化、またはダイジェスト・アルゴリズム。</td>
+    <td>エンコーディング、暗号化、またはダイジェストアルゴリズム。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(例えば、<code>MD5</code>、<code>ES256</code>、または<code>ES512-256</code>)</td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-format--BearerSecurityScheme">
     <td><code>format</code></td>
-    <td>	セキュリティ認証情報の形式を指定します。</td>
+    <td>	セキュリティ認証情報の形式を指定する。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(例えば、<code>jwt</code>、<code>cwt</code>、<code>jwe</code>、または<code>jws</code>)</td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-in--BearerSecurityScheme">
     <td><code>in</code></td>
-    <td>セキュリティ認証情報の場所を指定します。</td>
+    <td>セキュリティ認証情報の場所を指定する。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(<code>header</code>、<code>query</code>、<code>body</code>、<code>cookie</code>のうちの1つ)</td>
   </tr>
@@ -2433,9 +2438,9 @@
 </section>
 <section id="psksecurityscheme">
 
-<h5 id="x5-3-3-7-psksecurityscheme"><bdi class="secno">5.3.3.7</bdi> <code>PSKSecurityScheme</code>(PSKセキュリティ・スキーム)<a class="self-link" aria-label="§" href="#psksecurityscheme"></a></h5>
+<h5 id="x5-3-3-7-psksecurityscheme"><bdi class="secno">5.3.3.7</bdi> <code>PSKSecurityScheme</code>(PSKセキュリティスキーム)<a class="self-link" aria-label="§" href="#psksecurityscheme"></a></h5>
 
-<p><code>psk</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別される事前共有キー認証セキュリティ設定(つまり、<code>"scheme": "psk"</code>)。</p>
+<p><code>psk</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別される事前共有キー認証セキュリティ<span class="mark">構成情報</span>(つまり、<code>"scheme": "psk"</code>)。</p>
 
 <table class="def">
 <thead>
@@ -2459,9 +2464,9 @@
 </section>
 <section id="oauth2securityscheme">
 
-<h5 id="x5-3-3-8-oauth2securityscheme"><bdi class="secno">5.3.3.8</bdi> <code>OAuth2SecurityScheme</code>(OAuth2セキュリティ・スキーム)<a class="self-link" aria-label="§" href="#oauth2securityscheme"></a></h5>
+<h5 id="x5-3-3-8-oauth2securityscheme"><bdi class="secno">5.3.3.8</bdi> <code>OAuth2SecurityScheme</code>(OAuth2セキュリティスキーム)<a class="self-link" aria-label="§" href="#oauth2securityscheme"></a></h5>
 
-<p><code>oauth2</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別される、[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6749" title="The OAuth 2.0 Authorization Framework">RFC6749</a></cite>]と[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8252" title="OAuth 2.0 for Native Apps">RFC8252</a></cite>]に適合するシステムのためのOAuth2認証セキュリティ設定です(つまり、<code>"scheme": "oauth2"</code>)。<span class="rfc2119-assertion" id="td-security-oauth2-code-flow"><code>code</code>のフローでは、<code>authorization</code>と<code>token</code>の両方が含まれていなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><code>SecurityScheme</code>で<code>scopes</code>が定義されていなければ、それは空と見なされます。</p>
+<p><code>oauth2</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別される、[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6749" title="The OAuth 2.0 Authorization Framework">RFC6749</a></cite>]と[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8252" title="OAuth 2.0 for Native Apps">RFC8252</a></cite>]に適合するシステムのためのOAuth2認証セキュリティ<span class="mark">構成情報</span>である(つまり、<code>"scheme": "oauth2"</code>)。<span class="rfc2119-assertion" id="td-security-oauth2-code-flow"><code>code</code>のフローでは、<code>authorization</code>と<code>token</code>の両方が含まれていなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><code>SecurityScheme</code>で<code>scopes</code>が定義されていなければ、それは空と見なされる。</p>
 
 <table class="def">
 <thead>
@@ -2475,13 +2480,13 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-authorization--OAuth2SecurityScheme">
     <td><code>authorization</code></td>
-    <td>承認サーバーのURI。</td>
+    <td><span class="mark">認可</span>サーバーのURI。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-token--OAuth2SecurityScheme">
     <td><code>token</code></td>
-    <td>トークン・サーバーのURI。</td>
+    <td>トークンサーバーのURI。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
@@ -2493,13 +2498,13 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-scopes--OAuth2SecurityScheme">
     <td><code>scopes</code></td>
-    <td>配列として提供される承認範囲識別子の集合。これらは、クライアントがアクセスできる資源とその方法を識別するために、承認サーバーによって返されたトークンで提供され、フォームに関連付けられます。フォームに関連付けられる値は、そのフォームでアクティブな<code>OAuth2SecurityScheme</code>で定義されているものから選択すべきです。</td>
+    <td>配列として提供される<span class="mark">認可</span>範囲識別子の集合。これらは、クライアントがアクセスできる資源とその方法を識別するために、<span class="mark">認可</span>サーバーによって返されたトークンで提供され、フォームに関連付けられる。フォームに関連付けられる値は、そのフォームでアクティブな<code>OAuth2SecurityScheme</code>で定義されているものから選択すべきである。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-flow--OAuth2SecurityScheme">
     <td><code>flow</code></td>
-    <td>承認フロー。</td>
+    <td><span class="mark">認可</span>フロー。</td>
     <td>必須</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(例えば、<code>code</code>)</td>
   </tr>
@@ -2512,13 +2517,13 @@
 
 <h4 id="x5-3-4-hypermedia-controls-vocabulary-definitions"><bdi class="secno">5.3.4</bdi> ハイパーメディア制御語彙の定義<a class="self-link" aria-label="§" href="#sec-hypermedia-vocabulary-definition"></a></h4>
 
-<p>現在のモデルは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が公開する(型付きの)ウェブ・リンクとウェブ・フォームの表現を提供します。<code>Link</code>クラスの定義は、ウェブ・リンク[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8288" title="Web Linking">RFC8288</a></cite>]で定義されている用語の非常に一般的なサブセットを反映したものです。定義された用語は、例えば、<i>照明というモノ</i>が<i>スイッチというモノ</i>によって制御されるなど、別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>との関係を記述するために使用できます。<code>Form</code>クラスは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>(および、その他のウェブ資源)の状態を操作するために新たに導入されたハイパーメディア制御のフォームに対応しています。</p>
+<p>現在のモデルは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が公開する(型付きの)ウェブリンクとウェブフォームの表現を提供する。<code>Link</code>クラスの定義は、ウェブリンク[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8288" title="Web Linking">RFC8288</a></cite>]で定義されている用語の非常に一般的なサブセットを反映したものである。定義された用語は、例えば、<i>照明という<span class="mark">Thing</span></i>が<i>スイッチという<span class="mark">Thing</span></i>によって制御されるなど、別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>との関係を記述するために使用できる。<code>Form</code>クラスは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>(および、その他のウェブ資源)の状態を操作するために新たに導入されたハイパーメディア制御のフォームに対応している。</p>
 
 <section id="link">
 
 <h5 id="x5-3-4-1-link"><bdi class="secno">5.3.4.1</bdi> <code>Link</code>(リンク)<a class="self-link" aria-label="§" href="#link"></a></h5>
 
-<p>リンクは、「<b><em>リンク・コンテキスト</em></b>の<b><em>リンク・ターゲット</em></b>には<b><em>関係型</em></b>の資源がある」という形のステートメントとして見ることができ、オプションの<b><em>ターゲット属性</em></b>で資源を詳細に記述できます。</p>
+<p>リンクは、「<b><em>リンクコンテキスト</em></b>の<b><em>リンクターゲット</em></b>には<b><em>関係型</em></b>の資源がある」という形のステートメントとして見ることができ、オプションの<b><em>ターゲット属性</em></b>で資源を詳細に記述できる。</p>
 
 <table class="def">
 <thead>
@@ -2538,19 +2543,19 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-type--Link">
     <td><code>type</code></td>
-    <td>リンクの逆参照の結果のメディア・タイプ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]が何であるべきかを示すヒントを提供するターゲット属性。</td>
+    <td>リンクの逆参照の結果のメディアタイプ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]が何であるべきかを示すヒントを提供するターゲット属性。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-rel--Link">
     <td><code>rel</code></td>
-    <td>リンク関係型はリンクのセマンティクスを識別します。</td>
+    <td>リンク関係型はリンクのセマンティクスを識別する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-anchor--Link">
     <td><code>anchor</code></td>
-    <td>指定されたURIまたはIRIでリンク・コンテキスト(デフォルトでは、その<code>id</code>で識別されるモノ自体)を上書きします。</td>
+    <td>指定されたURIまたはIRIでリンクコンテキスト(デフォルトでは、その<code>id</code>で識別される<span class="mark">Thing</span>自体)を上書きする。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI"><code>anyURI</code></a></td>
   </tr>
@@ -2562,7 +2567,7 @@
 
 <h5 id="x5-3-4-2-form"><bdi class="secno">5.3.4.2</bdi> <code>Form</code>(フォーム)<a class="self-link" aria-label="§" href="#form"></a></h5>
 
-<p>フォームは、「<b><em>フォーム・コンテキスト</em></b>で<b><em>操作型</em></b>の操作を実行するために、<b><em>送信ターゲット</em></b>に<b><em>リクエスト・メソッド</em></b>のリクエストを行う」というステートメントとして見ることができ、オプションの<b><em>フォーム・フィールド</em></b>で、必要なリクエストを詳細に記述できます。モノの記述では、<b><em>フォーム・コンテキスト</em></b>は、プロパティー、アクション、イベントなどの周囲のオブジェクト、またはメタ対話のモノ自体です。</p>
+<p>フォームは、「<b><em>フォームコンテキスト</em></b>で<b><em>操作型</em></b>の操作を実行するために、<b><em>送信ターゲット</em></b>に<b><em>リクエストメソッド</em></b>のリクエストを行う」というステートメントとして見ることができ、オプションの<b><em>フォームフィールド</em></b>で、必要なリクエストを詳細に記述できる。<span class="mark">Thing Description</span>では、<b><em>フォームコンテキスト</em></b>は、<span class="mark">Property</span>、<span class="mark">Action</span>、<span class="mark">Event</span>などの周囲のオブジェクト、またはメタ相互作用の<span class="mark">Thing</span>自体である。</p>
 
 <table class="def">
 <thead>
@@ -2576,7 +2581,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-op--Form">
     <td><code>op</code></td>
-    <td>フォームで記述された操作を実行するセマンティックな意図を示します。例えば、プロパティーの対話では、getとsetの操作が可能です。プロトコル・バインディングには、get操作用のフォームと、別のset操作用フォームを含むことができます。op属性は、フォームの対象を示し、必要な操作に適したフォームをクライアントが選択できるようにします。opには、それぞれに操作のセマンティックな意図を表す1つ以上の対話の動詞を割り当てることができます。</td>
+    <td>フォームで記述された操作を実行するセマンティックな意図を示す。例えば、<span class="mark">Property</span>の相互作用では、getとsetの操作が可能である。プロトコルバインディングには、get操作用のフォームと、別のset操作用フォームを含むことができる。op属性は、フォームの対象を示し、必要な操作に適したフォームをクライアントが選択できるようにする。opには、それぞれに操作のセマンティックな意図を表す1つ以上の相互作用の動詞を割り当てることができる。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>(<code>readproperty</code>、<code>writeproperty</code>、<code>observeproperty</code>、<code>unobserveproperty</code>、<code>invokeaction</code>、<code>subscribeevent</code>、<code>unsubscribeevent</code>、<code>readallproperties</code>、<code>writeallproperties</code>、<code>readmultipleproperties</code>、<code>writemultipleproperties</code>のうちの1つ)</td>
   </tr>
@@ -2588,50 +2593,50 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-contentType--Form">
     <td><code>contentType</code></td>
-    <td>メディア・タイプ(例えば、<code>text/plain</code>)と、そのメディア・タイプの潜在的なパラメータ(例えば、<code>charset=utf-8</code>)[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]に基づいてコンテンツ・タイプを割り当てます。</td>
+    <td>メディアタイプ(例えば、<code>text/plain</code>)と、そのメディアタイプの潜在的なパラメータ(例えば、<code>charset=utf-8</code>)[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]に基づいてコンテンツタイプを割り当てる。</td>
     <td><a href="#sec-default-values">デフォルトあり</a></td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-contentCoding--Form">
     <td><code>contentCoding</code></td>
-    <td>コンテンツ・コーディングの値は、表現に適用された、または適用できるエンコーディング変換を示します。コンテンツ・コーディングは、その基礎となるメディア・タイプが同一のままで、かつ、情報を失うことなく、表現を圧縮したり、そうでない場合は便利に変換したりするために主に用います。コンテンツ・コーディングの例には、「gzip」、「deflate」などがあります。</td>
+    <td>コンテンツコーディングの値は、表現に適用された、または適用できるエンコーディング変換を示す。コンテンツコーディングは、その基礎となるメディアタイプが同一のままで、かつ、情報を失うことなく、表現を圧縮したり、そうでない場合は便利に変換したりするために主に用いる。コンテンツコーディングの例には、「gzip」、「deflate」などがある。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-subprotocol--Form">
     <td><code>subprotocol</code></td>
-    <td>複数のオプションがある場合に、特定のプロトコルで対話が達成される厳密なメカニズムを示します。例えば、HTTPやイベントの場合、ロング・ポーリング(<code>longpoll</code>)、WebSub[<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>](<code>websub</code>)、サーバー送信イベント(<code>sse</code>)[<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite>](EventSourceとしても知られている)などの非同期通知に使用可能ないくつかのメカニズムのどれを用いるかを示します。サブプロトコルの選択に制限はなく、このサブプロトコル用語で他のメカニズムも告知できることに注意してください。</td>
+    <td>複数のオプションがある場合に、特定のプロトコルで相互作用が達成される厳密なメカニズムを示す。例えば、HTTPや<span class="mark">Event</span>の場合、ロングポーリング(<code>longpoll</code>)、WebSub[<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>](<code>websub</code>)、サーバー送信<span class="mark">Event</span>(<code>sse</code>)[<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">html</a></cite>](EventSourceとしても知られている)などの非同期通知に使用可能ないくつかのメカニズムのどれを用いるかを示す。サブプロトコルの選択に制限はなく、このサブプロトコル用語で他のメカニズムも告知できることに注意していただきたい。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>(例えば、<code>longpoll</code>、<code>websub</code>、または<code>sse</code>)</td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-security--Form">
     <td><code>security</code></td>
-    <td>セキュリティ定義名の集合。<code>securityDefinitions</code>で定義されているものから選定します。資源にアクセスするためには、これらすべてが満たされていなければなりません。</td>
+    <td>セキュリティ定義名の集合。<code>securityDefinitions</code>で定義されているものから選定する。資源にアクセスするためには、これらすべてが満たされていなければならない。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-scopes--Form">
     <td><code>scopes</code></td>
-    <td>配列として提供される承認範囲識別子の集合。これらは、クライアントがアクセスできる資源とその方法を識別するために、承認サーバーによって返されたトークンで提供され、フォームに関連付けられます。フォームに関連付けられる値は、そのフォームでアクティブな<code>OAuth2SecurityScheme</code>で定義されているものから選択すべきです。</td>
+    <td>配列として提供される<span class="mark">認可</span>範囲識別子の集合。これらは、クライアントがアクセスできる資源とその方法を識別するために、<span class="mark">認可</span>サーバーによって返されたトークンで提供され、フォームに関連付けられる。フォームに関連付けられる値は、そのフォームでアクティブな<code>OAuth2SecurityScheme</code>で定義されているものから選択すべきである。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>または<a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-response--Form">
     <td><code>response</code></td>
-    <td>このオプションの用語は、例えば、出力の通信メタデータが入力のメタデータと異なる場合(例えば、出力コンテンツ・タイプが入力コンテンツ・タイプと異なる場合)に使用できます。応答の名前には、応答メッセージにのみ有効なメタデータが含まれます。</td>
+    <td>このオプションの用語は、例えば、出力の通信メタデータが入力のメタデータと異なる場合(例えば、出力コンテンツタイプが入力コンテンツタイプと異なる場合)に使用できる。応答の名前には、応答メッセージにのみ有効なメタデータが含まれる。</td>
     <td>オプション</td>
     <td><a href="#expectedresponse"><code>ExpectedResponse</code></a></td>
   </tr>
 </tbody>
 </table>
 
-<p><code>contentCoding</code>プロパティーの可能な値は、例えば、<a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">IANA HTTPコンテンツ・コーディング・レジストリ</a>にあります。</p>
+<p><code>contentCoding</code>プロパティーの可能な値は、例えば、<a href="https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding">IANA HTTPコンテンツコーディングレジストリ</a>にありる。</p>
 
-<p>フォームの可能な操作型のリストは固定されています。このバージョンの仕様の時点では、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]で記述されているWoT対話モデルを実装するために必要な既知の型のみが含まれています。この標準の将来のバージョンでは、このリストは拡張される可能性がありますが、<span class="rfc2119-assertion" id="well-known-operation-types-only">操作型は、サービエントが任意に設定すべきではありません(<em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em>)。</span></p>
+<p>フォームの可能な操作型のリストは固定されている。このバージョンの仕様の時点では、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]で記述されているWoT<span class="mark">相互作用モデル</span>を実装するために必要な既知の型のみが含まれている。この標準の将来のバージョンでは、このリストは拡張される可能性があるが、<span class="rfc2119-assertion" id="well-known-operation-types-only">操作型は、サービエントが任意に設定すべきではない(<em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em>)。</span></p>
 
-<p>オプションの<code>response</code>の名前-値のペアを用いて、予期される応答メッセージのメタデータを提供できます。コア語彙では、コンテンツ・タイプ情報のみが含まれていますが、TDコンテキスト拡張を適用できます。<span class="rfc2119-assertion" id="td-expectedResponse-default-contentType"><code>response</code>の名前-値のペアが提供されていない場合は、応答のコンテンツ・タイプがFormインスタンスに割り当てられているコンテンツ・タイプと等しいと想定しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><code>ExpectedResponse</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>内の<code>contentType</code>には<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>がないことに注意してください。例えば、フォームのコンテンツ・タイプの値が<code>application/xml</code>の場合、想定される応答のコンテンツ・タイプの値も<code>application/xml</code>になります。</p>
+<p>オプションの<code>response</code>の名前-値のペアを用いて、予期される応答メッセージのメタデータを提供できる。コア語彙では、コンテンツタイプ情報のみが含まれているが、TDコンテキスト拡張を適用できる。<span class="rfc2119-assertion" id="td-expectedResponse-default-contentType"><code>response</code>の名前-値のペアが提供されていない場合は、応答のコンテンツタイプがFormインスタンスに割り当てられているコンテンツタイプと等しいと想定しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><code>ExpectedResponse</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>内の<code>contentType</code>には<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>がないことに注意していただきたい。例えば、フォームのコンテンツタイプの値が<code>application/xml</code>の場合、想定される応答のコンテンツタイプの値も<code>application/xml</code>になる。</p>
 
-<p>ユースケースによっては、例えば、JSONを受け入れるけれども画像を返すアクションなど、入力と出力のデータが異なる形式で表される場合があります。そのようなケースでは、オプションの<code>response</code>の名前-値のペアで、予期される応答のコンテンツ・タイプを記述することができます。<span class="rfc2119-assertion" id="td-expectedResponse-contentType">予期される応答のコンテンツ・タイプがフォームのコンテンツ・タイプと異なる場合には、<code>Form</code>インスタンスに<code>response</code>という名前を持つ名前-値のペアを含めなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span>例えば、<code>ActionAffordance</code>は、入力データでは<code>application/json</code>のみを受け入れ、出力データでは<code>image/jpeg</code>というコンテンツ・タイプで応答する可能性があります。その場合、コンテンツ・タイプが異なり、<code>response</code>の名前-値のペアを用いて、応答コンテンツ・タイプ(<code>image/jpeg</code>)の情報を<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>に提供しなければなりません。</p>
+<p>ユースケースによっては、例えば、JSONを受け入れるけれども画像を返す<span class="mark">Action</span>など、入力と出力のデータが異なる形式で表される場合がある。そのようなケースでは、オプションの<code>response</code>の名前-値のペアで、予期される応答のコンテンツタイプを記述することができる。<span class="rfc2119-assertion" id="td-expectedResponse-contentType">予期される応答のコンテンツタイプがフォームのコンテンツタイプと異なる場合には、<code>Form</code>インスタンスに<code>response</code>という名前を持つ名前-値のペアを含めなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>例えば、<code>ActionAffordance</code>は、入力データでは<code>application/json</code>のみを受け入れ、出力データでは<code>image/jpeg</code>というコンテンツタイプで応答する可能性がある。その場合、コンテンツタイプが異なり、<code>response</code>の名前-値のペアを用いて、応答コンテンツタイプ(<code>image/jpeg</code>)の情報を<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に提供しなければならない。</p>
 
 </section>
 <section id="expectedresponse">
@@ -2652,7 +2657,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-contentType--ExpectedResponse">
     <td><code>contentType</code></td>
-    <td>メディア・タイプ(例えば、<code>text/plain</code>)と、そのメディア・タイプの潜在的なパラメータ(例えば、<code>charset=utf-8</code>)[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]に基づいてコンテンツ・タイプを割り当てます。</td>
+    <td>メディアタイプ(例えば、<code>text/plain</code>)と、そのメディアタイプの潜在的なパラメータ(例えば、<code>charset=utf-8</code>)[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]に基づいてコンテンツタイプを割り当てる。</td>
     <td>必須</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#string"><code>string</code></a></td>
   </tr>
@@ -2666,9 +2671,9 @@
 
 <h3 id="x5-4-default-value-definitions"><bdi class="secno">5.4</bdi> デフォルト値の定義<a class="self-link" aria-label="§" href="#sec-default-values"></a></h3>
 
-<p><span class="rfc2119-assertion" id="td-vocabulary-defaults">TDの割り当てが欠落している場合、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>の表で表されている<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>の割り当てに従わなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-vocabulary-defaults">TDの割り当てが欠落している場合、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>の表で表されている<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>の割り当てに従わなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>次の表で、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>で定義しているすべての<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を示します。</p>
+<p>次の表で、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>で定義しているすべての<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を示す。</p>
 
 <table class="def">
 <thead>
@@ -2779,13 +2784,13 @@
 
 <h2 id="x6-td-representation-format"><bdi class="secno">6.</bdi> TD表現形式<a class="self-link" aria-label="§" href="#sec-td-serialization"></a></h2>
 
-<p>WoTモノの記述はモノを表し、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>に基づいてモデル化され構造化されます。この項では、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>で定義している<code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスのシリアル化である、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のJSONベースの表現形式を定義します。</p>
+<p><span class="mark">WoT Thing Description</span>は<span class="mark">Thing</span>を表し、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>に基づいてモデル化され構造化される。この項では、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>で定義している<code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスの<span class="mark">シリアライゼーション</span>である、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のJSONベースの表現形式を定義する。</p>
 
-<p><span class="rfc2119-assertion" id="td-processor-serialization"><a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、<a href="#td-basic-types-mapping" class="sec-ref">§&nbsp;<bdi class="secno">6.1</bdi> JSONの型へのマッピング</a>と<a href="#td-class-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.3</bdi> 情報モデルのシリアル化</a>で記述している規則に従って、<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>のJSON形式[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8259" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC8259</a></cite>]へのシリアル化および/またはその形式からの<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn">モノの記述</a>の逆シリアル化ができなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-processor-serialization"><a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、<a href="#td-basic-types-mapping" class="sec-ref">§&nbsp;<bdi class="secno">6.1</bdi> JSONの型へのマッピング</a>と<a href="#td-class-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.3</bdi> 情報モデルの<span class="mark">シリアライゼーション</span></a>で記述している規則に従って、<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>のJSON形式[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8259" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC8259</a></cite>]への<span class="mark">シリアライズ</span>および/またはその形式からの<a href="#dfn-thing-description" class="internalDFN" data-link-type="dfn"><span class="mark">Thing Description</span></a>の<span class="mark">逆シリアライズ</span>ができなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のJSONシリアル化は、セマンティックの評価を合理化するために、JSON-LD 1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]の構文との整合化を図っています。したがって、TD表現形式は未加工のJSONとして処理するか、JSON-LD 1.1プロセッサで処理するかのいずれかが可能です(セマンティックな処理の詳細に関しては、<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> JSON-LDコンテキストの使用法</a>や、<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下のドキュメントを参照してください)。</p>
+<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のJSON<span class="mark">シリアライゼーション</span>は、セマンティックの評価を合理化するために、JSON-LD 1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]の構文との整合化を図っている。したがって、TD表現形式は未加工のJSONとして処理するか、JSON-LD 1.1プロセッサで処理するかのいずれかが可能である(セマンティックな処理の詳細に関しては、<a href="#json-ld-ctx-usage" class="sec-ref">§&nbsp;<bdi class="secno">D.</bdi> JSON-LDコンテキストの使用法</a>や、<a href="https://www.w3.org/2019/wot/td">https://www.w3.org/2019/wot/td</a>などの名前空間IRI下のドキュメントを参照)。</p>
 
-<p>相互運用可能な国際化をサポートするには、<span class="rfc2119-assertion" id="td-json-open">オープン・エコシステムに関するRFC8259[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8259" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC8259</a></cite>]の8.1項で定義されている要件に従ってTDをシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span>要約すると、これには次が必要です。</p>
+<p>相互運用可能な国際化をサポートするには、<span class="rfc2119-assertion" id="td-json-open">オープンエコシステムに関するRFC8259[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8259" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC8259</a></cite>]の8.1項で定義されている要件に従ってTDを<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>要約すると、これには次が必要である。</p>
 
 <ul>
   <li><span class="rfc2119-assertion" id="td-json-open_utf-8">TDはUTF-8[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3629" title="UTF-8, a transformation format of ISO 10646">RFC3629</a></cite>]を用いてエンコードしなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
@@ -2797,24 +2802,24 @@
 
 <h3 id="x6-1-mapping-to-json-types"><bdi class="secno">6.1</bdi> の型へのマッピング<a class="self-link" aria-label="§" href="#td-basic-types-mapping"></a></h3>
 
-<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、モデルの<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>とJSONの型の間に簡単なマッピングが存在するように構築されます。すべての<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスはJSONオブジェクトにマッピングされ、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスの個々の名前-値のペアは、JSONオブジェクトのメンバーです。</p>
+<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>は、モデルの<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>とJSONの型の間に簡単なマッピングが存在するように構築される。すべての<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスはJSONオブジェクトにマッピングされ、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスの個々の名前-値のペアは、JSONオブジェクトのメンバーである。</p>
 
-<p><a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラス定義</a>で言及しているすべての<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>(つまり、<code>string</code>、<code>anyURI</code>、<code>dateTime</code>、<code>integer</code>、<code>unsignedInt</code>、<code>double</code>、および<code>boolean</code>)は、以下に列挙している規則に従って、プリミティブなJSONの型(文字列、数値、ブール値)にマッピングされます。これらの規則は、名前-値のペアの値に適用されます。</p>
+<p><a href="#class-definitions" class="sec-ref">§&nbsp;<bdi class="secno">5.3</bdi> クラス定義</a>で言及しているすべての<a href="#dfn-simple-type" class="internalDFN" data-link-type="dfn">単純型</a>(つまり、<code>string</code>、<code>anyURI</code>、<code>dateTime</code>、<code>integer</code>、<code>unsignedInt</code>、<code>double</code>、および<code>boolean</code>)は、以下に列挙している規則に従って、プリミティブなJSONの型(文字列、数値、ブール値)にマッピングされる。これらの規則は、名前-値のペアの値に適用される。</p>
 
 <ul>
-  <li><span class="rfc2119-assertion" id="td-string-type"><code>string</code>型または<code>anyURI</code>型の値は、JSON文字列としてシリアル化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="td-datetime-type"><code>dateTime</code>型の値は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3339" title="Date and Time on the Internet: Timestamps">RFC3339</a></cite>]で指定されている「日時」形式に従ってJSON文字列としてシリアル化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>例には、<code>2019-05-24T13:12:45Z</code>や<code>2015-07-11T09:32:26+08:00</code>が含まれる。<span class="rfc2119-assertion" id="td-datetime-recommended-type"><code>dateTime</code>型の値は、オフセットではなくUTCタイム・ゾーンを表す<code>Z</code>というリテラルを用いるべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="td-integer-type"><code>integer</code>型または<code>unsignedInt</code>型の値は、小数部または指数部のないJSON数値としてシリアル化しなければならない<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="td-number-type"><code>double</code>型の値は、JSON数値としてシリアル化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="td-boolean-type"><code>boolean</code>型の値は、JSONブールとしてシリアル化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-string-type"><code>string</code>型または<code>anyURI</code>型の値は、JSON文字列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-datetime-type"><code>dateTime</code>型の値は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3339" title="Date and Time on the Internet: Timestamps">RFC3339</a></cite>]で指定されている「日時」形式に従ってJSON文字列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>例には、<code>2019-05-24T13:12:45Z</code>や<code>2015-07-11T09:32:26+08:00</code>が含まれる。<span class="rfc2119-assertion" id="td-datetime-recommended-type"><code>dateTime</code>型の値は、オフセットではなくUTCタイムゾーンを表す<code>Z</code>というリテラルを用いるべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-integer-type"><code>integer</code>型または<code>unsignedInt</code>型の値は、小数部または指数部のないJSON数値として<span class="mark">シリアライズ</span>しなければならない<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-number-type"><code>double</code>型の値は、JSON数値として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-boolean-type"><code>boolean</code>型の値は、JSONブールとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
 </ul>
 
-<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のすべての複合型(つまり、<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>、および<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス)は、以下に列挙している規則に従って、構造化されたJSONの型(配列およびオブジェクト)にマッピングされます。</p>
+<p><a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のすべての複合型(つまり、<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>、および<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス)は、以下に列挙している規則に従って、構造化されたJSONの型(配列およびオブジェクト)にマッピングされる。</p>
 
 <ul>
-  <li><span class="rfc2119-assertion" id="td-array-type"><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型の値は、名前-値のペアの各値を、JSON配列の要素として、ペアの数値名順に並べて、JSON配列としてシリアル化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="td-map-type"><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ型</a>の値は、名前-値の各ペアを、JSONオブジェクトのメンバーにして、JSONオブジェクトとしてシリアル化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="td-class-type"><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスは、<a href="#td-class-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.3</bdi> 情報モデルのシリアル化</a>で個別に指定している詳細な規則に従って、JSONオブジェクトとしてシリアル化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-array-type"><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型の値は、名前-値のペアの各値を、JSON配列の要素として、ペアの数値名順に並べて、JSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-map-type"><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ型</a>の値は、名前-値の各ペアを、JSONオブジェクトのメンバーにして、JSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-class-type"><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスは、<a href="#td-class-serialization" class="sec-ref">§&nbsp;<bdi class="secno">6.3</bdi> 情報モデルの<span class="mark">シリアライゼーション</span></a>で個別に指定している詳細な規則に従って、JSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
 </ul>
 
 </section>
@@ -2822,14 +2827,14 @@
 
 <h3 id="x6-2-omitting-default-values"><bdi class="secno">6.2</bdi> デフォルト値の省略<a class="self-link" aria-label="§" href="#omitting-default-values"></a></h3>
 
-<p>モノの記述のシリアル化では、<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>の表で列挙している、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が定義されている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を省略できます。</p>
+<p><span class="mark">Thing Description</span>の<span class="mark">シリアライゼーション</span>では、<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>の表で列挙している、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が定義されている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を省略できる。</p>
 
-<p>次の例は、<a href="#simple-thing-description-sample">例1</a>のTDのインスタンスに、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>でメンバーも含めるチェック・ボックスを付けたものです(チェック・ボックスにチェックあり)。これらのメンバーは、TDシリアル化を簡素化するために省略できます(チェック・ボックスにチェックなし)。<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、これらの省略されたメンバーを、特定の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>で明示的に存在しているのと完く同じように解釈することに注意してください。</p>
+<p>次の例は、<a href="#simple-thing-description-sample">例1</a>のTDのインスタンスに、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>でメンバーも含めるチェックボックスを付けたものである(チェックボックスにチェックあり)。これらのメンバーは、TD<span class="mark">シリアライゼーション</span>を簡素化するために省略できる(チェックボックスにチェックなし)。<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、これらの省略されたメンバーを、特定の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>で明示的に存在しているのと完く同じように解釈することに注意していただきたい。</p>
 
 <aside class="example with-default" id="example-3">
 <div class="marker"><a class="self-link" href="#example-3">例<bdi>3</bdi></a></div>
 <div class="with-default-control">
-<input type="checkbox"> <span><i>with Default Values</i></span>
+<input type="checkbox"> <span><i>デフォルト値を使用</i></span>
 </div>
 <pre aria-busy="false"><code class="hljs json">{
     <span class="hljs-attr">"@context"</span>: <span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>,
@@ -2928,22 +2933,22 @@
 
 </aside>
 
-<p>用いられている<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>に応じて、追加のプロトコル固有の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>が適用されている場合があることに注意してください。<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が関連付けられている場合もあるため、この小項目で説明しているように省略することができます。詳細な情報は、<a href="#protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">8.3</bdi> プロトコル・バインディング</a>にあります。</p>
+<p>用いられている<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>に応じて、追加のプロトコル固有の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>が適用されている場合があることに注意していただきたい。<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>が関連付けられている場合もあるため、この小項目で説明しているように省略することができる。詳細な情報は、<a href="#protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">8.3</bdi> プロトコルバインディング</a>にある。</p>
 
 </section>
 <section id="td-class-serialization">
 
-<h3 id="x6-3-information-model-serialization"><bdi class="secno">6.3</bdi> 情報モデルのシリアル化<a class="self-link" aria-label="§" href="#td-class-serialization"></a></h3>
+<h3 id="x6-3-information-model-serialization"><bdi class="secno">6.3</bdi> 情報モデルの<span class="mark">シリアライゼーション</span><a class="self-link" aria-label="§" href="#td-class-serialization"></a></h3>
 
 <section id="sec-thing-as-a-whole-json">
 
-<h4 id="x6-3-1-thing-root-object"><bdi class="secno">6.3.1</bdi> モノのルート・オブジェクト<a class="self-link" aria-label="§" href="#sec-thing-as-a-whole-json"></a></h4>
+<h4 id="x6-3-1-thing-root-object"><bdi class="secno">6.3.1</bdi> <span class="mark">Thing</span>のルートオブジェクト<a class="self-link" aria-label="§" href="#sec-thing-as-a-whole-json"></a></h4>
 
-<p>モノの記述は、<a href="#thing"><code>Thing</code></a>型の<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>をルートとするデータ構造です。次に、モノの記述のJSONシリアル化はJSONオブジェクトであり、それは、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>から構築された構文ツリーのルートです。</p>
+<p><span class="mark">Thing Description</span>は、<a href="#thing"><code>Thing</code></a>型の<a href="#dfn-object" class="internalDFN" data-link-type="dfn">オブジェクト</a>をルートとするデータ構造である。次に、<span class="mark">Thing Description</span>のJSON<span class="mark">シリアライゼーション</span>はJSONオブジェクトであり、それは、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>から構築された構文ツリーのルートである。</p>
 
-<p><span class="rfc2119-assertion" id="td-context"><a href="#dfn-td-serialization" class="internalDFN" data-link-type="dfn">TDシリアル化</a>のルート要素は、<code>@context</code>という名前を持つメンバーと、<code>https://www.w3.org/2019/wot/td/v1</code>と等しいか、それぞれに含む文字列型または配列型の値を持つメンバーを含むJSONオブジェクトでなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-context"><a href="#dfn-td-serialization" class="internalDFN" data-link-type="dfn">TD<span class="mark">シリアライゼーション</span></a>のルート要素は、<code>@context</code>という名前を持つメンバーと、<code>https://www.w3.org/2019/wot/td/v1</code>と等しいか、それぞれに含む文字列型または配列型の値を持つメンバーを含むJSONオブジェクトでなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>一般的に、このURIは、この仕様で定義しているTD表現形式のバージョンを識別するために用います。JSON-LD処理[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]の場合、このURIはモノの記述のコンテキスト・ファイルを指定します。配列型の<code>@context</code>は、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を示します(詳細に関しては、<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>を参照してください)。</p>
+<p>一般的に、このURIは、この仕様で定義しているTD表現形式のバージョンを識別するために用いる。JSON-LD処理[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]の場合、このURIは<span class="mark">Thing Description</span>のコンテキストファイルを指定する。配列型の<code>@context</code>は、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を示す(詳細に関しては、<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>を参照)。</p>
 
 <div class="example" id="example-4">
 <div class="marker"><a class="self-link" href="#example-4">例<bdi>4</bdi></a></div>
@@ -2953,12 +2958,12 @@
 }</code></pre>
 </div>
 
-<p><span class="rfc2119-assertion" id="td-context-toplevel"><code>Thing</code>のインスタンスの名前-値のペアはすべて、名前が<code>Thing</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>内の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、ルート・オブジェクトのJSONメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-context-toplevel"><code>Thing</code>のインスタンスの名前-値のペアはすべて、名前が<code>Thing</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>内の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、ルートオブジェクトのJSONメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>すべての必須およびオプションのメンバーを含むシリアル化されたルート・オブジェクトのTDの断片を以下に示します。</p>
+<p>すべての必須およびオプションのメンバーを含む<span class="mark">シリアライズ</span>されたルートオブジェクトのTDの断片を以下に示す。</p>
 
 <div class="example" id="thing-serialization-sample">
-<div class="marker"><a class="self-link" href="#thing-serialization-sample">例<bdi>5</bdi></a><span class="example-title">: モノのシリアル化のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#thing-serialization-sample">例<bdi>5</bdi></a><span class="example-title">: <span class="mark">Thing</span>の<span class="mark">シリアライゼーション</span>のサンプル</span></div>
 <pre aria-busy="false"><code class="hljs javascript">{
     <span class="hljs-string">"@context"</span>: <span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>,
     <span class="hljs-string">"@type"</span>: <span class="hljs-string">"Thing"</span>,
@@ -2982,29 +2987,29 @@
 }</code></pre>
 </div>
 
-<p><span class="rfc2119-assertion" id="td-objects"><code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の<code>version</code>、<code>securityDefinitions</code>、<code>properties</code>、<code>actions</code>、および<code>events</code>に割り当てられているすべての値は、JSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-objects"><code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の<code>version</code>、<code>securityDefinitions</code>、<code>properties</code>、<code>actions</code>、および<code>events</code>に割り当てられているすべての値は、JSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-arrays"><code>links</code>に割り当てられているすべての値、および<code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の<code>forms</code>は、それぞれ<a href="#link-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.8</bdi> <code>links</code>(リンク)</a>と<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義しているJSONオブジェクトを含むJSON配列としてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-arrays"><code>links</code>に割り当てられているすべての値、および<code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の<code>forms</code>は、それぞれ<a href="#link-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.8</bdi> <code>links</code>(リンク)</a>と<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義しているJSONオブジェクトを含むJSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-security-activation"><code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の<code>security</code>に割り当てられている値は、JSON文字列またはJSON文字列を要素とするJSON配列としてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-security-activation"><code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内の<code>security</code>に割り当てられている値は、JSON文字列またはJSON文字列を要素とするJSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 <section id="titles-descriptions-serialization-json">
 
 <h4 id="x6-3-2-human-readable-metadata"><bdi class="secno">6.3.2</bdi> 人間が読めるメタデータ<a class="self-link" aria-label="§" href="#titles-descriptions-serialization-json"></a></h4>
 
-<p><code>title</code>および<code>description</code>という名前のJSONメンバーは、人間が読めるメタデータを提供するためにTDドキュメント内で用います。これらは、TDドキュメントの検査を行う開発者用のコメントとして、またはユーザ・インターフェース用の表示テキストとして使用できます。</p>
+<p><code>title</code>および<code>description</code>という名前のJSONメンバーは、人間が読めるメタデータを提供するためにTDドキュメント内で用いる。これらは、TDドキュメントの検査を行う開発者用のコメントとして、またはユーザインターフェース用の表示テキストとして使用できる。</p>
 
-<p><a href="#thing" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1.1</bdi> <code>Thing</code>(モノ)</a>で定義しているように、人間が読めるメタデータを表示するために用いられるテキストの基本書字方向は、最初の強い文字(first-strong)の規則などのヒューリスティクスを用いて推定するか、言語情報から推測することができます。TDドキュメントでは、デフォルトの言語は<code>@context</code>内の<code>@language</code>に割り当てられている値によって定義され、これは、必要に応じてスクリプト・サブタグとともに、テキストの基本書字方向を決定するために使用できます。<span class="rfc2119-assertion" id="td-context-default-language-direction-independence">しかし、人間が読めるテキストを解釈するときは、人間が読める各文字列値を個別に処理しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span>言い換えれば、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、ある文字列から別の文字列へと方向の変更を繰り越したり、ある文字の方向をTD内の他の場所から推測したりすることはできません。</p>
+<p><a href="#thing" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1.1</bdi> <code>Thing</code></a>で定義しているように、人間が読めるメタデータを表示するために用いられるテキストの基本書字方向は、最初の強い文字(first-strong)の規則などのヒューリスティクスを用いて推定するか、言語情報から推測することができる。TDドキュメントでは、デフォルトの言語は<code>@context</code>内の<code>@language</code>に割り当てられている値によって定義され、これは、必要に応じてスクリプトサブタグとともに、テキストの基本書字方向を決定するために使用できる。<span class="rfc2119-assertion" id="td-context-default-language-direction-independence">しかし、人間が読めるテキストを解釈するときは、人間が読める各文字列値を個別に処理しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>言い換えれば、<a href="#dfn-td-processor" class="internalDFN" data-link-type="dfn">TDプロセッサ</a>は、ある文字列から別の文字列へと方向の変更を繰り越したり、ある文字の方向をTD内の他の場所から推測したりすることはできない。</p>
 
 <div class="note" role="note" id="issue-container-generatedID-0">
 <div role="heading" class="note-title marker" id="h-note-0" aria-level="5"><span>注</span></div>
 
-<p class="">ウェブ上の文字列[<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta" title="Strings on the Web: Language and Direction Metadata">STRING-META</a></cite>]は、テキストの基本書字方向を決定する手段として、最初の強い文字(strong-first)と言語ベースの両方の推論を提案しています。モノの記述の形式がJSON-LD 1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]に基づいていて、現在のところ明示的な方向のメタデータが欠落していることを考えると、これらのアプローチはこの公開時点では適切であると考えられます。しかし、JSON-LD 1.1が[<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta" title="Strings on the Web: Language and Direction Metadata">STRING-META</a></cite>]で推奨されている明示的な基本書字方向のメタデータのサポートを採用した場合、その機能を利用するためにモノの記述の形式を更新すべきです。</p>
+<p class="">ウェブ上の文字列[<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta" title="Strings on the Web: Language and Direction Metadata">STRING-META</a></cite>]は、テキストの基本書字方向を決定する手段として、最初の強い文字(strong-first)と言語ベースの両方の推論を提案している。<span class="mark">Thing Description</span>の形式がJSON-LD 1.1[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]に基づいていて、現在のところ明示的な方向のメタデータが欠落していることを考えると、これらのアプローチはこの公開時点では適切であると考えられる。しかし、JSON-LD 1.1が[<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta" title="Strings on the Web: Language and Direction Metadata">STRING-META</a></cite>]で推奨されている明示的な基本書字方向のメタデータのサポートを採用した場合、その機能を利用するために<span class="mark">Thing Description</span>の形式を更新すべきである。</p>
 
 </div>
 
-<p><code>title</code>および<code>description</code>を用いたTDの断片を以下に示します。デフォルト言語は、<code>@context</code>配列のJSONオブジェクト内の<code>@language</code>メンバーの定義により<code>en</code>に設定されます。</p>
+<p><code>title</code>および<code>description</code>を用いたTDの断片を以下に示す。デフォルト言語は、<code>@context</code>配列のJSONオブジェクト内の<code>@language</code>メンバーの定義により<code>en</code>に設定される。</p>
 
 <div class="example" id="example-6">
 <div class="marker"><a class="self-link" href="#example-6">例<bdi>6</bdi></a></div>
@@ -3033,9 +3038,9 @@
 }</code></pre>
 </div>
 
-<p><code>titles</code>および<code>descriptions</code>という名前のJSONメンバーは、1つのTDドキュメント内で複数の言語で人間が読めるメタデータを提供するためにTDドキュメント内で用います。<span class="rfc2119-assertion" id="td-multi-languages"><code>MultiLanguage</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、JSONオブジェクトのメンバーとしてシリアル化しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、その名前は[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で定義されている整形式の言語タグであり、値はタグで示されている言語の人間が読める文字列です。</span>詳細に関しては、<a href="#multilanguage" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1.7</bdi> <code>MultiLanguage</code>(多言語)</a>を参照してください。<span class="rfc2119-assertion" id="td-multi-languages-consistent">TDドキュメント内のすべての<code>MultiLanguage</code>オブジェクトには、同じ言語メンバーの集合が含まれているべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
+<p><code>titles</code>および<code>descriptions</code>という名前のJSONメンバーは、1つのTDドキュメント内で複数の言語で人間が読めるメタデータを提供するためにTDドキュメント内で用いる。<span class="rfc2119-assertion" id="td-multi-languages"><code>MultiLanguage</code><a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、JSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、その名前は[<cite><a class="bibref" data-link-type="biblio" href="#bib-bcp47" title="Tags for Identifying Languages">BCP47</a></cite>]で定義されている整形式の言語タグであり、値はタグで示されている言語の人間が読める文字列である。</span>詳細に関しては、<a href="#multilanguage" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1.7</bdi> <code>MultiLanguage</code>(多言語)</a>を参照していただきたい。<span class="rfc2119-assertion" id="td-multi-languages-consistent">TDドキュメント内のすべての<code>MultiLanguage</code>オブジェクトには、同じ言語メンバーの集合が含まれているべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
 
-<p>様々なレベルで<code>titles</code>と<code>descriptions</code>を用いたTDの断片を以下に示します。</p>
+<p>様々なレベルで<code>titles</code>と<code>descriptions</code>を用いたTDの断片を以下に示す。</p>
 
 <div class="example" id="example-7">
 <div class="marker"><a class="self-link" href="#example-7">例<bdi>7</bdi></a></div>
@@ -3084,7 +3089,7 @@
 }</code></pre>
 </div>
 
-<p>TDのインスタンスは、<code>title</code>と<code>description</code>の使用を<code>titles</code>と<code>descriptions</code>と組み合わせることもできます。<span class="rfc2119-assertion" id="td-title-description"><code>title</code>および<code>titles</code>または<code>description</code>および<code>descriptions</code>が同じJSONオブジェクト内に存在している場合、<code>title</code>と<code>description</code>の値はデフォルトのテキストとして表示されるかもしれません(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="td-titles-descriptions"><code>title</code>および<code>titles</code>または<code>description</code>および<code>descriptions</code>がTDドキュメント内に存在する場合、個々の<code>title</code>と<code>description</code>のメンバーは、それぞれ対応する<code>titles</code>と<code>descriptions</code>のメンバーを持っているべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span>デフォルトのテキストの言語は、デフォルトの言語で示されます。これは通常、モノの記述のインスタンスの作成者が設定します。</p>
+<p>TDのインスタンスは、<code>title</code>と<code>description</code>の使用を<code>titles</code>と<code>descriptions</code>と組み合わせることもできる。<span class="rfc2119-assertion" id="td-title-description"><code>title</code>および<code>titles</code>または<code>description</code>および<code>descriptions</code>が同じJSONオブジェクト内に存在している場合、<code>title</code>と<code>description</code>の値はデフォルトのテキストとして表示されるかもしれない(<em class="rfc2119" title="MAY">MAY</em>)。</span><span class="rfc2119-assertion" id="td-titles-descriptions"><code>title</code>および<code>titles</code>または<code>description</code>および<code>descriptions</code>がTDドキュメント内に存在する場合、個々の<code>title</code>と<code>description</code>のメンバーは、それぞれ対応する<code>titles</code>と<code>descriptions</code>のメンバーを持っているべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span>デフォルトのテキストの言語は、デフォルトの言語で示される。これは通常、<span class="mark">Thing Description</span>のインスタンスの作成者が設定する。</p>
 
 <div class="example" id="example-8">
 <div class="marker"><a class="self-link" href="#example-8">例<bdi>8</bdi></a></div>
@@ -3139,16 +3144,16 @@
 }</code></pre>
 </div>
 
-<p>デフォルト言語を設定する別の可能性は、HTTPの<code>Accept-Language</code>ヘッダー・フィールドなどの言語交渉メカニズムを用いることです。<span class="rfc2119-assertion" id="td-ns-multilanguage-content-negotiation">デフォルト言語の交渉が行われた場合、交渉の結果と、返されるコンテンツの対応するデフォルト言語を示す<code>@language</code>メンバーが存在しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-ns-multilanguage-content-negotiation-no-multi">デフォルト言語の交渉が正常に行われた場合は、TDドキュメントは<code>titles</code>と<code>descriptions</code>のメンバーの<code>MultiLanguage</code>オブジェクトよりも優先して、メンバーである<code>title</code>と<code>description</code>に適切な一致する値を含めるべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span><span class="rfc2119-assertion" id="td-ns-multilanguage-content-negotiation-optional">しかし、モノは、そのような動的に生成されるTDのサポートも、言語交渉のサポートも行わないことを選択できる(<em class="rfc2119" title="MAY">MAY</em>)(例えば、資源の制約のために)ことに注意してください。</span></p>
+<p>デフォルト言語を設定する別の可能性は、HTTPの<code>Accept-Language</code>ヘッダーフィールドなどの言語交渉メカニズムを用いることである。<span class="rfc2119-assertion" id="td-ns-multilanguage-content-negotiation">デフォルト言語の交渉が行われた場合、交渉の結果と、返されるコンテンツの対応するデフォルト言語を示す<code>@language</code>メンバーが存在しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-ns-multilanguage-content-negotiation-no-multi">デフォルト言語の交渉が正常に行われた場合は、TDドキュメントは<code>titles</code>と<code>descriptions</code>のメンバーの<code>MultiLanguage</code>オブジェクトよりも優先して、メンバーである<code>title</code>と<code>description</code>に適切な一致する値を含めるべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span><span class="rfc2119-assertion" id="td-ns-multilanguage-content-negotiation-optional">しかし、<span class="mark">Thing</span>は、そのような動的に生成されるTDのサポートも、言語交渉のサポートも行わないことを選択できる(<em class="rfc2119" title="MAY">MAY</em>)(例えば、資源の制約のために)ことに注意していただきたい。</span></p>
 
 </section>
 <section id="version-serialization-json">
 
 <h4 id="x6-3-3-version"><bdi class="secno">6.3.3</bdi> <code>version</code>(バージョン)<a class="self-link" aria-label="§" href="#version-serialization-json"></a></h4>
 
-<p><span class="rfc2119-assertion" id="td-version">名前が、<code>VersionInfo</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である<code>VersionInfo</code>のインスタンスのすべての名前-値のペアは、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として持つJSONメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-version">名前が、<code>VersionInfo</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である<code>VersionInfo</code>のインスタンスのすべての名前-値のペアは、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として持つJSONメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>バージョン情報オブジェクトのTDの断片を以下に示します。</p>
+<p>バージョン情報オブジェクトのTDの断片を以下に示す。</p>
 
 <div class="example" id="example-9">
 <div class="marker"><a class="self-link" href="#example-9">例<bdi>9</bdi></a></div>
@@ -3159,18 +3164,18 @@
 }</code></pre>
 </div>
 
-<p><code>version</code>のメンバーは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>に基づく追加のアプリケーション固有および/またはデバイス固有のバージョン情報用のコンテナとして意図されています。詳細に関しては、<a href="#semantic-annotations" class="sec-ref">§&nbsp;<bdi class="secno">7.1</bdi> セマンティックなアノテーション</a>を参照してください。</p>
+<p><code>version</code>のメンバーは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>に基づく追加のアプリケーション固有および/またはデバイス固有のバージョン情報用のコンテナとして意図されている。詳細に関しては、<a href="#semantic-annotations" class="sec-ref">§&nbsp;<bdi class="secno">7.1</bdi> セマンティックなアノテーション</a>を参照していただきたい。</p>
 
 </section>
 <section id="security-serialization-json">
 
 <h4 id="x6-3-4-securitydefinitions-and-security"><bdi class="secno">6.3.4</bdi> <code>securityDefinitions</code>(セキュリティ定義)と<code>security</code>(セキュリティ)<a class="self-link" aria-label="§" href="#security-serialization-json"></a></h4>
 
-<p><code>Thing</code>のインスタンスでは、<code>securityDefinitions</code>に割り当てられている値は、<code>SecurityScheme</code>のインスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>です。<span class="rfc2119-assertion" id="td-security"><code>SecurityScheme</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(MUST)。ペアの名前はJSON文字列としてシリアル化しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>SecurityScheme</code>のインスタンス)は、JSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>Thing</code>のインスタンスでは、<code>securityDefinitions</code>に割り当てられている値は、<code>SecurityScheme</code>のインスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>である。<span class="rfc2119-assertion" id="td-security"><code>SecurityScheme</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>の<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(MUST)。ペアの名前はJSON文字列として<span class="mark">シリアライズ</span>しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>SecurityScheme</code>のインスタンス)は、JSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-security-schemes"><code>SecurityScheme</code>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のうちの1つのインスタンスのすべての名前-値のペアは、名前がその<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>または<code>SecurityScheme</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>SecurityScheme</code><a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のインスタンスのシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-security-schemes"><code>SecurityScheme</code>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のうちの1つのインスタンスのすべての名前-値のペアは、名前がその<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>または<code>SecurityScheme</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>SecurityScheme</code><a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のインスタンスの<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>次のTDの断片は、ヘッダーで基本的なユーザ名/パスワード認証を指定するシンプルなセキュリティ設定を示しています。<code>in</code>に指定される値は、実際には<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>(<code>header</code>)であり、省略できます。名前付きセキュリティ設定は<code>securityDefinitions</code>マップで指定しなければなりません。その定義は、<code>security</code>メンバーのそのJSON名によってアクティブ化しなければならず、それは、1つの定義のみがアクティブ化される場合には文字列型でありえます。</p>
+<p>次のTDの断片は、ヘッダーで基本的なユーザ名/パスワード認証を指定するシンプルなセキュリティ<span class="mark">構成情報</span>を示している。<code>in</code>に指定される値は、実際には<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>(<code>header</code>)であり、省略できる。名前付きセキュリティ<span class="mark">構成情報</span>は<code>securityDefinitions</code>マップで指定しなければならない。その定義は、<code>security</code>メンバーのそのJSON名によってアクティブ化しなければならず、それは、1つの定義のみがアクティブ化される場合には文字列型でありえる。</p>
 
 <div class="example" id="security-basic-example">
 <div class="marker"><a class="self-link" href="#security-basic-example">例<bdi>10</bdi></a></div>
@@ -3185,7 +3190,7 @@
 ...</code></pre>
 </div>
 
-<p>ここで、より複雑な例として、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>におけるベアラー・トークン認証と組み合わせたプロキシにおけるダイジェスト認証を示すTDの断片を示します。<code>digest</code>スキームでは、<code>in</code>の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>(つまり、<code>header</code>)は省略されますが、適用はされます。正常な対話を行うためには、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>内で、ユーザ名/パスワードやトークンなどの対応する非公開のセキュリティ設定を設定しなければならないことに注意してください。複数のセキュリティ定義をアクティブ化すると、<code>security</code>メンバーは配列になります。</p>
+<p>ここで、より複雑な例として、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>におけるベアラートークン認証と組み合わせたプロキシにおけるダイジェスト認証を示すTDの断片を示す。<code>digest</code>スキームでは、<code>in</code>の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>(つまり、<code>header</code>)は省略されるが、適用はされる。正常な相互作用を行うためには、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>内で、ユーザ名/パスワードやトークンなどの対応する非公開のセキュリティ<span class="mark">構成情報</span>を設定しなければならないことに注意していただきたい。複数のセキュリティ定義をアクティブ化すると、<code>security</code>メンバーは配列になる。</p>
 
 <div class="example" id="security-digest-example">
 <div class="marker"><a class="self-link" href="#security-digest-example">例<bdi>11</bdi></a></div>
@@ -3207,9 +3212,9 @@
 ...</code></pre>
 </div>
 
-<p>TDのセキュリティ設定は必須です。<span class="rfc2119-assertion" id="td-security-mandatory">モノのレベル(つまり、TDルート・オブジェクト)の<code>security</code>配列を介して少なくとも1つのセキュリティ定義をアクティブ化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span>この設定は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>との対話に必要なデフォルトのセキュリティ・メカニズムと見ることができます。<span class="rfc2119-assertion" id="td-security-overrides">セキュリティ定義は、フォーム・オブジェクトに<code>security</code>メンバーを含めることにより、フォームのレベルでアクティブ化することもでき(<em class="rfc2119" title="MAY">MAY</em>)、これは、モノのレベルでアクティブ化されるすべての定義を上書き(つまり、完全に置き換え)します。</span></p>
+<p>TDのセキュリティ<span class="mark">構成情報</span>は必須である。<span class="rfc2119-assertion" id="td-security-mandatory"><span class="mark">Thing</span>のレベル(つまり、TDルートオブジェクト)の<code>security</code>配列を介して少なくとも1つのセキュリティ定義をアクティブ化しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>この<span class="mark">構成</span>は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>との相互作用に必要なデフォルトのセキュリティメカニズムと見ることができる。<span class="rfc2119-assertion" id="td-security-overrides">セキュリティ定義は、フォームオブジェクトに<code>security</code>メンバーを含めることにより、フォームのレベルでアクティブ化することもでき(<em class="rfc2119" title="MAY">MAY</em>)、これは、<span class="mark">Thing</span>のレベルでアクティブ化されるすべての定義を上書き(つまり、完全に置き換え)する。</span></p>
 
-<p>セキュリティが必要ない場合、<code>nosec</code>セキュリティ・スキームが提供されます。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の最小限のセキュリティ設定は、次の例に示すように、モノのレベルでの<code>nosec</code>セキュリティ・スキームのアクティブ化です。</p>
+<p>セキュリティが必要ない場合、<code>nosec</code>セキュリティスキームが提供される。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の最小限のセキュリティ<span class="mark">構成情報</span>は、次の例に示すように、<span class="mark">Thing</span>のレベルでの<code>nosec</code>セキュリティスキームのアクティブ化である。</p>
 
 <div class="example" id="example-12">
 <div class="marker"><a class="self-link" href="#example-12">例<bdi>12</bdi></a></div>
@@ -3228,7 +3233,7 @@
 }</code></pre>
 </div>
 
-<p>より複雑な例を示すために、認証が不要なものを除き、すべての<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>で基本認証を必要な<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>があると仮定します。<code>status</code>プロパティーと<code>toggle</code>アクションの場合、<code>basic</code>認証が必要であり、モノのレベルで定義されます。しかし、<code>overheating</code>イベントの場合は、認証は必要ないため、セキュリティ設定はフォームのレベルで上書きされます。</p>
+<p>より複雑な例を示すために、認証が不要なものを除き、すべての<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>で基本認証を必要な<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>があると仮定する。<code>status</code> <span class="mark">Property</span>と<code>toggle</code> <span class="mark">Action</span>の場合、<code>basic</code>認証が必要であり、<span class="mark">Thing</span>のレベルで定義される。しかし、<code>overheating</code> <span class="mark">Event</span>の場合は、認証は必要ないため、セキュリティ<span class="mark">構成情報</span>はフォームのレベルで上書きされる。</p>
 
 <div class="example" id="example-13">
 <div class="marker"><a class="self-link" href="#example-13">例<bdi>13</bdi></a></div>
@@ -3268,7 +3273,7 @@
 }</code></pre>
 </div>
 
-<p>セキュリティ設定は、同じ<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>内の様々なフォーム用に指定することもできます。これは、様々なセキュリティ・メカニズムをサポートする、HTTPやCoAP[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>]などの、複数のプロトコルをサポートするデバイスに必要でありえます。これは、代替認証メカニズムが許されている場合にも役立ちます。ここでは、基本認証を用いたHTTPS経由、ダイジェスト認証、ベアラー・トークン認証という、プロパティー・アフォーダンスをアクティブ化する3つの可能な方法を示すTDの断片を示します。言い換えると、複数のフォーム内で様々なセキュリティ設定を用いると、セキュリティ・メカニズムを「OR」方式で組み合わせることができます。対照的に、同じ<code>security</code>メンバーに複数のセキュリティ設定を配置すると、それらは「AND」方式で結合されます。これは、その場合には、<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>のアクティブ化を可能にするために、それらすべてを満たす必要があるためです。モノのレベルで1つの(デフォルトの)構成をアクティブ化することは依然として必須であることに注意してください。</p>
+<p>セキュリティ<span class="mark">構成情報</span>は、同じ<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>内の様々なフォーム用に指定することもできる。これは、様々なセキュリティメカニズムをサポートする、HTTPやCoAP[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>]などの、複数のプロトコルをサポートするデバイスに必要でありえる。これは、代替認証メカニズムが許されている場合にも役立つ。ここでは、基本認証を用いたHTTPS経由、ダイジェスト認証、ベアラートークン認証という、<span class="mark">Propertyの</span>アフォーダンスをアクティブ化する3つの可能な方法を示すTDの断片を示す。言い換えると、複数のフォーム内で様々なセキュリティ<span class="mark">構成情報</span>を用いると、セキュリティメカニズムを「OR」方式で組み合わせることができる。対照的に、同じ<code>security</code>メンバーに複数のセキュリティ<span class="mark">構成情報</span>を配置すると、それらは「AND」方式で結合される。これは、その場合には、<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>のアクティブ化を可能にするために、それらすべてを満たす必要があるためである。<span class="mark">Thing</span>のレベルで1つの(デフォルトの)<span class="mark">構成</span>をアクティブ化することは依然として必須であることに注意していただきたい。</p>
 
 <div class="example" id="example-14">
 <div class="marker"><a class="self-link" href="#example-14">例<bdi>14</bdi></a></div>
@@ -3299,7 +3304,7 @@
 }</code></pre>
 </div>
 
-<p>別のより複雑な例として、OAuth2は範囲を用います。これはトークンに現れる識別子であり、その資源(または、<abbr title="World Wide Web Consortium">W3C</abbr> WoTの場合は<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>)へのアクセスを可能にするために、資源内の対応する識別子と一致しなければなりません。例えば、下記では、<code>limited</code>という範囲を含むベアラー・トークンを用いて<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>が<code>status</code>プロパティーを読むことができますが、<code>configure</code>アクションは、<code>special</code>の範囲を含むトークンでのみ呼び出すことができます。範囲は役割と同一ではありませんが、多くの場合それに関連付けられています。例えば、おそらく管理的な役割を持つもののみが「特別な」対話を実行する承認を与えられます。トークンは複数のスコープを持つことができます。この例では、管理者にはおそらく<code>limited</code>と<code>special</code>の両方の範囲を持つトークンが発行されますが、通常のユーザには<code>limited</code>の範囲のトークンのみが発行されます。</p>
+<p>別のより複雑な例として、OAuth2は範囲を用いる。これはトークンに現れる識別子であり、その資源(または、<abbr title="World Wide Web Consortium">W3C</abbr> WoTの場合は<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>)へのアクセスを可能にするために、資源内の対応する識別子と一致しなければならない。例えば、下記では、<code>limited</code>という範囲を含むベアラートークンを用いて<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>が<code>status</code> <span class="mark">Property</span>を読むことができるが、<code>configure</code> <span class="mark">Action</span>は、<code>special</code>の範囲を含むトークンでのみ呼び出すことができる。範囲は役割と同一ではないが、多くの場合それに関連付けられている。例えば、おそらく管理的な役割を持つもののみが「特別な」相互作用を実行する<span class="mark">認可</span>を与えられる。トークンは複数のスコープを持つことができる。この例では、管理者にはおそらく<code>limited</code>と<code>special</code>の両方の範囲を持つトークンが発行されるが、通常のユーザには<code>limited</code>の範囲のトークンのみが発行される。</p>
 
 <div class="example" id="example-15">
 <div class="marker"><a class="self-link" href="#example-15">例<bdi>15</bdi></a></div>
@@ -3343,16 +3348,16 @@
 
 <h4 id="x6-3-5-properties"><bdi class="secno">6.3.5</bdi> <code>properties</code>(プロパティー)<a class="self-link" aria-label="§" href="#property-serialization-json"></a></h4>
 
-<p><code>Thing</code>のインスタンスの<code>properties</code>に割り当てられる値は、<code>PropertyAffordance</code>のインスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>です。<span class="rfc2119-assertion" id="td-properties"><code>PropertyAffordance</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。ペアの名前はJSON文字列としてシリアル化しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>PropertyAffordance</code>のインスタンス)はJSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>Thing</code>のインスタンスの<code>properties</code>に割り当てられる値は、<code>PropertyAffordance</code>のインスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>である。<span class="rfc2119-assertion" id="td-properties"><code>PropertyAffordance</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>の<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。ペアの名前はJSON文字列として<span class="mark">シリアライズ</span>しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>PropertyAffordance</code>のインスタンス)はJSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-property-names"><code>PropertyAffordance</code>のインスタンスのすべての名前-値のペアは、名前が<code>PropertyAffordance</code>、<code>InteractionAffordance</code>、または<code>DataSchema</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(の1つ)に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>PropertyAffordance</code>インスタンスのシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>インスタンスのシリアル化の詳細に関しては、<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> データ・スキーマ</a>を参照してください。</p>
+<p><span class="rfc2119-assertion" id="td-property-names"><code>PropertyAffordance</code>のインスタンスのすべての名前-値のペアは、名前が<code>PropertyAffordance</code>、<code>InteractionAffordance</code>、または<code>DataSchema</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(の1つ)に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>PropertyAffordance</code>インスタンスの<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>インスタンスの<span class="mark">シリアライズ</span>の詳細に関しては、<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> <span class="mark">Data Schema</span></a>を参照していただきたい。</p>
 
-<p><span class="rfc2119-assertion" id="td-property-arrays"><code>PropertyAffordance</code>のインスタンスの<code>forms</code>に割り当てられている値は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している1つ以上のJSONオブジェクトのシリアル化を含むJSON配列としてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-property-arrays"><code>PropertyAffordance</code>のインスタンスの<code>forms</code>に割り当てられている値は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している1つ以上のJSONオブジェクトの<span class="mark">シリアライゼーション</span>を含むJSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>2つの<a href="#dfn-property" class="internalDFN" data-link-type="dfn">プロパティー</a>・アフォーダンスの断片を以下に示します。</p>
+<p>2つの<a href="#dfn-property" class="internalDFN" data-link-type="dfn"><span class="mark">Property</span></a>アフォーダンスの断片を以下に示す。</p>
 
 <aside class="example" id="property-serialization-sample">
-<div class="marker"><a class="self-link" href="#property-serialization-sample">例<bdi>16</bdi></a><span class="example-title">: プロパティーのシリアル化のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#property-serialization-sample">例<bdi>16</bdi></a><span class="example-title">: <span class="mark">Property</span>の<span class="mark">シリアライゼーション</span>のサンプル</span></div>
 <pre aria-busy="false"><code class="hljs javascript">...
 <span class="hljs-string">"properties"</span>: {
     <span class="hljs-string">"on"</span>: {
@@ -3389,18 +3394,18 @@
 
 <h4 id="x6-3-6-actions"><bdi class="secno">6.3.6</bdi> <code>actions</code>(アクション)<a class="self-link" aria-label="§" href="#action-serialization-json"></a></h4>
 
-<p><code>Thing</code>のインスタンスでは、<code>actions</code>に割り当てられる値は<code>ActionAffordance</code>のインスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>です。<span class="rfc2119-assertion" id="td-actions"><code>ActionAffordance</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。ペアの名前はJSON文字列としてシリアル化しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>ActionAffordance</code>のインスタンス)はJSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>Thing</code>のインスタンスでは、<code>actions</code>に割り当てられる値は<code>ActionAffordance</code>のインスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>である。<span class="rfc2119-assertion" id="td-actions"><code>ActionAffordance</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>の<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。ペアの名前はJSON文字列として<span class="mark">シリアライズ</span>しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>ActionAffordance</code>のインスタンス)はJSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-action-names"><code>ActionAffordance</code>のインスタンスのすべての名前-値のペアは、名前が<code>ActionAffordance</code>または<code>InteractionAffordance</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(の1つ)に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>ActionAffordance</code>インスタンスのシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-action-names"><code>ActionAffordance</code>のインスタンスのすべての名前-値のペアは、名前が<code>ActionAffordance</code>または<code>InteractionAffordance</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(の1つ)に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>ActionAffordance</code>インスタンスの<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-action-objects"><code>ActionAffordance</code>のインスタンス内で<code>input</code>および<code>output</code>に割り当てられている値は、JSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span>それらは、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>に依拠しており、そのシリアル化は<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> データ・スキーマ</a>で定義しています。</p>
+<p><span class="rfc2119-assertion" id="td-action-objects"><code>ActionAffordance</code>のインスタンス内で<code>input</code>および<code>output</code>に割り当てられている値は、JSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>それらは、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>に依拠しており、その<span class="mark">シリアライゼーション</span>は<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> <span class="mark">Data Schema</span></a>で定義している。</p>
 
-<p><span class="rfc2119-assertion" id="td-action-arrays"><code>ActionAffordance</code>のインスタンス内の<code>forms</code>に割り当てられている値は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している1つ以上のJSONオブジェクトのシリアル化を含むJSON配列としてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-action-arrays"><code>ActionAffordance</code>のインスタンス内の<code>forms</code>に割り当てられている値は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している1つ以上のJSONオブジェクトの<span class="mark">シリアライゼーション</span>を含むJSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>アクション・アフォーダンスのTDの断片を以下に示します。</p>
+<p><span class="mark">Actionの</span>アフォーダンスのTDの断片を以下に示す。</p>
 
 <aside class="example" id="action-serialization-sample">
-<div class="marker"><a class="self-link" href="#action-serialization-sample">例<bdi>17</bdi></a><span class="example-title">: アクションのシリアル化のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#action-serialization-sample">例<bdi>17</bdi></a><span class="example-title">: <span class="mark">Action</span>の<span class="mark">シリアライゼーション</span>のサンプル</span></div>
 <pre aria-busy="false"><code class="hljs javascript">...
 <span class="hljs-string">"actions"</span>: {
     <span class="hljs-string">"fade"</span> : {
@@ -3434,18 +3439,18 @@
 
 <h4 id="x6-3-7-events"><bdi class="secno">6.3.7</bdi> <code>events</code>(イベント)<a class="self-link" aria-label="§" href="#event-serialization-json"></a></h4>
 
-<p><code>Thing</code>のインスタンスでは、<code>events</code>に割り当てられる値は、<code>EventAffordance</code>のインスタンスのマップです。<span class="rfc2119-assertion" id="td-events"><code>EventAffordance</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。ペアの名前はJSON文字列としてシリアル化しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>EventAffordance</code>のインスタンス)はJSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>Thing</code>のインスタンスでは、<code>events</code>に割り当てられる値は、<code>EventAffordance</code>のインスタンスのマップである。<span class="rfc2119-assertion" id="td-events"><code>EventAffordance</code>インスタンスの<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>のすべての名前-値のペアは、<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>の<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。ペアの名前はJSON文字列として<span class="mark">シリアライズ</span>しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、ペアの値(<code>EventAffordance</code>のインスタンス)はJSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-event-names"><code>EventAffordance</code>のインスタンスのすべての名前-値のペアは、名前が<code>EventAffordance</code>または<code>InteractionAffordance</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(の1つ)に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>EventAffordance</code>インスタンスのシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-event-names"><code>EventAffordance</code>のインスタンスのすべての名前-値のペアは、名前が<code>EventAffordance</code>または<code>InteractionAffordance</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>(の1つ)に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>EventAffordance</code>インスタンスの<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-event-objects"><code>EventAffordance</code>のインスタンス内で<code>subscription</code>、<code>data</code>、そして<code>cancellation</code>に割り当てられている値は、JSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span>それらは、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>に依拠しており、そのシリアル化は<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> データ・スキーマ</a>で定義しています。</p>
+<p><span class="rfc2119-assertion" id="td-event-objects"><code>EventAffordance</code>のインスタンス内で<code>subscription</code>、<code>data</code>、そして<code>cancellation</code>に割り当てられている値は、JSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>それらは、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>に依拠しており、その<span class="mark">シリアライゼーション</span>は<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> <span class="mark">Data Schema</span></a>で定義している。</p>
 
-<p><span class="rfc2119-assertion" id="td-event-arrays"><code>EventAffordance</code>のインスタンス内の<code>forms</code>に割り当てられている値は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している1つ以上のJSONオブジェクトのシリアル化を含むJSON配列としてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-event-arrays"><code>EventAffordance</code>のインスタンス内の<code>forms</code>に割り当てられている値は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している1つ以上のJSONオブジェクトの<span class="mark">シリアライゼーション</span>を含むJSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>イベント・オブジェクトのTDの断片を以下に示します。</p>
+<p><span class="mark">Event</span>オブジェクトのTDの断片を以下に示す。</p>
 
 <aside class="example" id="event-serialization-sample">
-<div class="marker"><a class="self-link" href="#event-serialization-sample">例<bdi>18</bdi></a><span class="example-title">: イベントのシリアル化のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#event-serialization-sample">例<bdi>18</bdi></a><span class="example-title">: <span class="mark">Event</span>の<span class="mark">シリアライゼーション</span>のサンプル</span></div>
 <pre aria-busy="false"><code class="hljs javascript">...
 <span class="hljs-string">"events"</span>: {
     <span class="hljs-string">"overheated"</span>: {
@@ -3458,19 +3463,19 @@
 ...</code></pre>
 </aside>
 
-<p>既存の(例えば、WebSub[<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>])または顧客指向のイベント・メカニズム(例えば、Webhooks)を採用するために、イベント・アフォーダンスは柔軟な方法で定義されています。このため、<code>subscription</code>と<code>cancellation</code>は、望ましいメカニズムに従って定義できます。詳細に関しては、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]をご覧ください。<a href="#webhook-example-serialization" class="sec-ref">§&nbsp;<bdi class="secno">A.3</bdi> Webhookイベントの例</a>の例は、イベントが<code>subscription</code>と<code>cancellation</code>を用いてWebhookを記述する方法を示しています。</p>
+<p>既存の(例えば、WebSub[<cite><a class="bibref" data-link-type="biblio" href="#bib-websub" title="WebSub">websub</a></cite>])または顧客指向の<span class="mark">出来事</span>メカニズム(例えば、Webhooks)を採用するために、<span class="mark">Eventの</span>アフォーダンスは柔軟な方法で定義されている。このため、<code>subscription</code>と<code>cancellation</code>は、望ましいメカニズムに従って定義できる。詳細に関しては、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]を参照していただきたい。<a href="#webhook-example-serialization" class="sec-ref">§&nbsp;<bdi class="secno">A.3</bdi> Webhook <span class="mark">Event</span>の例</a>の例は、<span class="mark">Event</span>が<code>subscription</code>と<code>cancellation</code>を用いてWebhookを記述する方法を示している。</p>
 
 </section>
 <section id="link-serialization-json">
 
 <h4 id="x6-3-8-links"><bdi class="secno">6.3.8</bdi> <code>links</code>(リンク)<a class="self-link" aria-label="§" href="#link-serialization-json"></a></h4>
 
-<p><span class="rfc2119-assertion" id="td-links"><code>Link</code>のインスタンスのすべての名前-値のペアは、名前が<code>Link</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>Link</code>インスタンスのシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-links"><code>Link</code>のインスタンスのすべての名前-値のペアは、名前が<code>Link</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>Link</code>インスタンスの<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><code>links</code>配列内のリンク・オブジェクトのTDの断片を以下に示します。</p>
+<p><code>links</code>配列内のリンクオブジェクトのTDの断片を以下に示す。</p>
 
 <aside class="example" id="link-serialization-sample">
-<div class="marker"><a class="self-link" href="#link-serialization-sample">例<bdi>19</bdi></a><span class="example-title">: リンクのシリアル化のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#link-serialization-sample">例<bdi>19</bdi></a><span class="example-title">: リンクの<span class="mark">シリアライゼーション</span>のサンプル</span></div>
 <pre aria-busy="false"><code class="hljs javascript">...
 <span class="hljs-string">"links"</span>: [{
     <span class="hljs-string">"rel"</span>: <span class="hljs-string">"controlledBy"</span>,
@@ -3484,14 +3489,14 @@
 
 <h4 id="x6-3-9-forms"><bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)<a class="self-link" aria-label="§" href="#form-serialization-json"></a></h4>
 
-<p><span class="rfc2119-assertion" id="td-forms"><code>Form</code>のインスタンスのすべての名前-値のペアは、名前が<code>Form</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>Form</code>インスタンスのシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-forms"><code>Form</code>のインスタンスのすべての名前-値のペアは、名前が<code>Form</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>Form</code>インスタンスの<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-form-protocolbindings">必要に応じて、フォーム・オブジェクトは、接頭辞で識別されるプロトコル固有の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で補完できます(<em class="rfc2119" title="MAY">MAY</em>)。</span><a href="#protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">8.3</bdi> プロトコル・バインディング</a>も参照してください。</p>
+<p><span class="rfc2119-assertion" id="td-form-protocolbindings">必要に応じて、フォームオブジェクトは、接頭辞で識別されるプロトコル固有の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で補完できる(<em class="rfc2119" title="MAY">MAY</em>)。</span><a href="#protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">8.3</bdi> プロトコルバインディング</a>も参照していただきたい。</p>
 
-<p><code>forms</code>配列内のフォーム・オブジェクトのTDの断片を以下に示します。</p>
+<p><code>forms</code>配列内のフォームオブジェクトのTDの断片を以下に示す。</p>
 
 <aside class="example" id="form-serialization-sample">
-<div class="marker"><a class="self-link" href="#form-serialization-sample">例<bdi>20</bdi></a><span class="example-title">: フォームのシリアル化のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#form-serialization-sample">例<bdi>20</bdi></a><span class="example-title">: フォームの<span class="mark">シリアライゼーション</span>のサンプル</span></div>
 <pre aria-busy="false"><code class="hljs javascript">...
 <span class="hljs-string">"forms"</span>: [{
     <span class="hljs-string">"op"</span>: <span class="hljs-string">"writeproperty"</span>,
@@ -3502,13 +3507,13 @@
 ...</code></pre>
 </aside>
 
-<p><code>href</code>には、http://192.168.1.25/left?p=2&d=1のpやdなどの動的変数を含むURIを含めることもできます。その場合、URIは[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6570" title="URI Template">RFC6570</a></cite>]で定義されているテンプレート(<code>http://192.168.1.25/left{?p,d}</code>)として定義できます。</p>
+<p><code>href</code>には、http://192.168.1.25/left?p=2&d=1のpやdなどの動的変数を含むURIを含めることもできる。その場合、URIは[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6570" title="URI Template">RFC6570</a></cite>]で定義されているテンプレート(<code>http://192.168.1.25/left{?p,d}</code>)として定義できる。</p>
 
-<p><span class="rfc2119-assertion" id="td-uriVariables-names">このようなケースでは、URIテンプレート変数は、関連する(一意な)変数名をJSON名として持つJSONオブジェクト・ベースの<code>uriVariables</code>メンバーで収集されなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-uriVariables-names">このようなケースでは、URIテンプレート変数は、関連する(一意な)変数名をJSON名として持つJSONオブジェクトベースの<code>uriVariables</code>メンバーで収集されなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-uriVariables-dataschema"><code>Form</code>のインスタンス内の<code>uriVariables</code>に割り当てられているマップの各値のシリアル化は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>に依拠しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、そのシリアル化は<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> データ・スキーマ</a>で定義しています。</span></p>
+<p><span class="rfc2119-assertion" id="td-uriVariables-dataschema"><code>Form</code>のインスタンス内の<code>uriVariables</code>に割り当てられているマップの各値の<span class="mark">シリアライゼーション</span>は、<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a>に依拠しなければならず(<em class="rfc2119" title="MUST">MUST</em>)、その<span class="mark">シリアライゼーション</span>は<a href="#data-schema-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.10</bdi> <span class="mark">Data Schema</span></a>で定義している。</span></p>
 
-<p>URIテンプレートと<code>uriVariables</code>を用いたTDの断片を以下に示します。</p>
+<p>URIテンプレートと<code>uriVariables</code>を用いたTDの断片を以下に示す。</p>
 
 <div class="example" id="example-21">
 <div class="marker"><a class="self-link" href="#example-21">例<bdi>21</bdi></a></div>
@@ -3536,7 +3541,7 @@
 }</code></pre>
 </div>
 
-<p><code>contentType</code>メンバーは、<code>;</code>という文字で区切られた属性-値のペアとしてメディア・タイプ・パラメータを含む、メディア・タイプ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]を割り当てるために用います。例は次のとおり。</p>
+<p><code>contentType</code>メンバーは、<code>;</code>という文字で区切られた属性-値のペアとしてメディアタイプパラメータを含む、メディアタイプ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]を割り当てるために用いる。例は次のとおり。</p>
 
 <div class="example" id="example-22">
 <div class="marker"><a class="self-link" href="#example-22">例<bdi>22</bdi></a></div>
@@ -3545,11 +3550,11 @@
 ...</code></pre>
 </div>
 
-<p>ユースケースによっては、<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>のフォーム・メタデータはリクエストを記述するだけでなく、予期される応答に関するメタデータも提供します。例えば、アクション<code>takePhoto</code>は、リクエスト・ペイロードにJSONを用いて(つまり、<code>"contentType": "application/json"</code>)、カメラのパラメータ設定(絞り優先、タイマーなど)を送信する<code>input</code>スキーマを定義します。このアクションの出力は、撮影された写真であり、例えば、JPEG形式で利用可能です。このような場合、応答ペイロードの表現形式を示すために<code>response</code>メンバーが用いられます(例えば、<code>"contentType": "image/jpeg"</code>)。ここでは、コンテンツ・タイプで表現形式が完全に指定されるため、<code>output</code>スキーマは必要ありません。</p>
+<p>ユースケースによっては、<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>のフォームメタデータはリクエストを記述するだけでなく、予期される応答に関するメタデータも提供する。例えば、<code>takePhoto</code> <span class="mark">Action</span>は、リクエストペイロードにJSONを用いて(つまり、<code>"contentType": "application/json"</code>)、カメラのパラメータ設定(絞り優先、タイマーなど)を送信する<code>input</code>スキーマを定義しする。このアクションの出力は、撮影された写真であり、例えば、JPEG形式で利用可能である。このような場合、応答ペイロードの表現形式を示すために<code>response</code>メンバーが用いられる(例えば、<code>"contentType": "image/jpeg"</code>)。ここでは、コンテンツタイプで表現形式が完全に指定されるため、<code>output</code>スキーマは必要ない。</p>
 
-<p><span class="rfc2119-assertion" id="td-form-response-object"><code>Form</code>のインスタンス内の<code>response</code>に割り当てられている値は、存在している場合、JSONオブジェクトでなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-forms-response">応答オブジェクトには、存在している場合、<a href="#expectedresponse" class="sec-ref"><code>ExpectedResponse</code></a>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義で定義されている<code>contentType</code>メンバーが含まれていなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-form-response-object"><code>Form</code>のインスタンス内の<code>response</code>に割り当てられている値は、存在している場合、JSONオブジェクトでなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span><span class="rfc2119-assertion" id="td-forms-response">応答オブジェクトには、存在している場合、<a href="#expectedresponse" class="sec-ref"><code>ExpectedResponse</code></a>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義で定義されている<code>contentType</code>メンバーが含まれていなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>上記の<code>takePhoto</code>アクションに基づいて、<code>response</code>メンバーを持つ<code>form</code>の断片を以下に示します。</p>
+<p>上記の<code>takePhoto</code> <span class="mark">Action</span>に基づいて、<code>response</code>メンバーを持つ<code>form</code>の断片を以下に示す。</p>
 
 <div class="example" id="example-23">
 <div class="marker"><a class="self-link" href="#example-23">例<bdi>23</bdi></a></div>
@@ -3572,7 +3577,7 @@
 }</code></pre>
 </div>
 
-<p><code>forms</code>が最上レベルに存在している場合は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が提供するメタ対話を記述するために使用できます。例えば、「readallproperties」および「writeallproperties」という操作型は、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>がすべてのプロパティーを一度に読み書きできる<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>とのメタ対話のためのものです。下記の例では、<code>forms</code>メンバーがTDのルート・オブジェクトに含まれており、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>は、送信ターゲット<code>https://mylamp.example.com/allproperties</code>を用いて、1回のプロトコル・トランザクションで<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のすべてのプロパティー(つまり、<code>on</code>、<code>brightness</code>、<code>timer</code>)の読み書きの両方を行うことができます。</p>
+<p><code>forms</code>が最上レベルに存在している場合は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が提供するメタ相互作用を記述するために使用できる。例えば、「readallproperties」および「writeallproperties」という操作型は、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>がすべてのプロパティーを一度に読み書きできる<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>とのメタ相互作用のためのものである。下記の例では、<code>forms</code>メンバーがTDのルートオブジェクトに含まれており、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>は、送信ターゲット<code>https://mylamp.example.com/allproperties</code>を用いて、1回のプロトコルトランザクションで<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のすべての<span class="mark">Property</span>(つまり、<code>on</code>、<code>brightness</code>、<code>timer</code>)の読み書きの両方を行うことができる。</p>
 
 <div class="example" id="td-forms-readall-example">
 <div class="marker"><a class="self-link" href="#td-forms-readall-example">例<bdi>24</bdi></a></div>
@@ -3607,29 +3612,29 @@
 }</code></pre>
 </div>
 
-操作型<code>writeallproperties</code>の場合、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>がすべての書き込み可能な(<code>readOnly</code>でない)プロパティーと(新しい)割り当てられた値(例えば、ペイロード内)を提供することが予期されます。同様に、<code>writemultipleproperties</code>操作型では、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>が書き込み可能な(<code>readOnly</code>ではない)プロパティーを提供することが予期されます。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>側では、<code>readmultipleproperties</code>および<code>readallproperties</code>の操作型の場合に、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は読み取り可能な(<code>writeOnly</code>ではない)プロパティーを返すことが予期されます。
+操作型<code>writeallproperties</code>の場合、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>がすべての書き込み可能な(<code>readOnly</code>でない)プロパティーと(新しい)割り当てられた値(例えば、ペイロード内)を提供することが予期される。同様に、<code>writemultipleproperties</code>操作型では、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>が書き込み可能な(<code>readOnly</code>ではない)プロパティーを提供することが予期される。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>側では、<code>readmultipleproperties</code>および<code>readallproperties</code>の操作型の場合に、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は読み取り可能な(<code>writeOnly</code>ではない)プロパティーを返すことが予期される。
 
 </section>
 <section id="data-schema-serialization-json">
 
-<h4 id="x6-3-10-data-schemas"><bdi class="secno">6.3.10</bdi> データ・スキーマ<a class="self-link" aria-label="§" href="#data-schema-serialization-json"></a></h4>
+<h4 id="x6-3-10-data-schemas"><bdi class="secno">6.3.10</bdi> <span class="mark">Data Schema</span><a class="self-link" aria-label="§" href="#data-schema-serialization-json"></a></h4>
 
-<p><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を通じて定義されるWoT モノの記述のデータ・スキーマは、JSONスキーマ用語[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]のサブセットに基づいています。したがって、TDデータ・スキーマのシリアル化をJSONスキーマ検証ソフトの実装に直接フィードして、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と交換されるデータを検証できます。</p>
+<p><a href="#dataschema" class="sec-ref"><code>DataSchema</code></a><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>を通じて定義される<span class="mark">WoT Thing Description</span>のデータスキーマは、JSONスキーマ用語[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]のサブセットに基づいている。したがって、TDデータスキーマの<span class="mark">シリアライゼーション</span>をJSONスキーマ検証ソフトの実装に直接フィードして、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と交換されるデータを検証できる。</p>
 
-<p>データ・スキーマのシリアル化は、<code>PropertyAffordance</code>インスタンス、<code>ActionAffordance</code>インスタンス内の<code>input</code>および<code>output</code>に割り当てられている値、<code>EventAffordance</code>インスタンス内の<code>subscription</code>、<code>data</code>、<code>cancellation</code>に割り当てられている値、<code>InteractionAffordance</code>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のインスタンス内の<code>uriVariables</code>に割り当てられている値(<a href="#form-serialization-json">フォーム・オブジェクト</a>がURIテンプレートを用いる場合)に適用されます。</p>
+<p>データスキーマの<span class="mark">シリアライゼーション</span>は、<code>PropertyAffordance</code>インスタンス、<code>ActionAffordance</code>インスタンス内の<code>input</code>および<code>output</code>に割り当てられている値、<code>EventAffordance</code>インスタンス内の<code>subscription</code>、<code>data</code>、<code>cancellation</code>に割り当てられている値、<code>InteractionAffordance</code>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のインスタンス内の<code>uriVariables</code>に割り当てられている値(<a href="#form-serialization-json">フォームオブジェクト</a>がURIテンプレートを用いる場合)に適用される。</p>
 
-<p><span class="rfc2119-assertion" id="td-data-schema"><code>DataSchema</code>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のうちの1つのインスタンスのすべての名前-値のペアは、名前がその<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>または<code>DataSchema</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>DataSchema</code><a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のインスタンスのシリアル化から生じるJSONオブジェクトのメンバーとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-data-schema"><code>DataSchema</code>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のうちの1つのインスタンスのすべての名前-値のペアは、名前がその<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>または<code>DataSchema</code>の<a href="#dfn-signature" class="internalDFN" data-link-type="dfn">シグネチャ</a>に含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である場合、<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を名前として用いて、<code>DataSchema</code><a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>のインスタンスの<span class="mark">シリアライズ</span>から生じるJSONオブジェクトのメンバーとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-data-schema-objects"><code>ObjectSchema</code>のインスタンス内の<code>properties</code>に割り当てられている値は、JSONオブジェクトとしてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-data-schema-objects"><code>ObjectSchema</code>のインスタンス内の<code>properties</code>に割り当てられている値は、JSONオブジェクトとして<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-data-schema-arrays"><code>DataSchema</code>のインスタンス内の<code>enum</code>、<code>required</code>、<code>oneOf</code>に割り当てられている値は、JSON配列としてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-data-schema-arrays"><code>DataSchema</code>のインスタンス内の<code>enum</code>、<code>required</code>、<code>oneOf</code>に割り当てられている値は、JSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p><span class="rfc2119-assertion" id="td-data-schema-objects-arrays"><code>ArraySchema</code>のインスタンス内の<code>items</code>に割り当てられている値は、JSONオブジェクトまたはJSONオブジェクトを含んだJSON配列としてシリアル化しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="td-data-schema-objects-arrays"><code>ArraySchema</code>のインスタンス内の<code>items</code>に割り当てられている値は、JSONオブジェクトまたはJSONオブジェクトを含んだJSON配列として<span class="mark">シリアライズ</span>しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
-<p>TDの断片のデータ・スキーマ・メンバーを以下に示します。周囲のオブジェクトは、データ・スキーマ・オブジェクト(例えば、<code>input</code>および<code>output</code>用)またはプロパティー・オブジェクトであり、追加のメンバーが含まれていることに注意してください。</p>
+<p>TDの断片のデータスキーマメンバーを以下に示す。周囲のオブジェクトは、データスキーマオブジェクト(例えば、<code>input</code>および<code>output</code>用)または<span class="mark">Property</span>オブジェクトであり、追加のメンバーが含まれていることに注意していただきたい。</p>
 
 <aside class="example" id="dataschema-serialization-sample">
-<div class="marker"><a class="self-link" href="#dataschema-serialization-sample">例<bdi>25</bdi></a><span class="example-title">: DataSchemaのシリアル化のサンプル</span></div>
+<div class="marker"><a class="self-link" href="#dataschema-serialization-sample">例<bdi>25</bdi></a><span class="example-title">: DataSchemaの<span class="mark">シリアライゼーション</span>のサンプル</span></div>
 <pre aria-busy="false"><code class="hljs javascript">...
 <span class="hljs-string">"type"</span>: <span class="hljs-string">"object"</span>,
 <span class="hljs-string">"properties"</span>: {
@@ -3659,9 +3664,9 @@
 ...</code></pre>
 </aside>
 
-<p><code>readOnly</code>および<code>writeOnly</code>という用語は、読み取り対話(つまり、プロパティーの読み取り時)で交換されるデータ項目と、書き込み対話(つまり、プロパティーの書き込み時)で交換されるデータ項目を示すために使用できます。これは、規定的ではない<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のプロパティーが読み取りと書き込みで異なるデータを示す場合の回避策として使用でき、それは、モノの記述で既存のデバイスまたはサービスを拡張する場合に当てはまります。</p>
+<p><code>readOnly</code>および<code>writeOnly</code>という用語は、読み取りの相互作用(つまり、<span class="mark">Property</span>の読み取り時)で交換されるデータ項目と、書き込みの相互作用(つまり、<span class="mark">Property</span>の書き込み時)で交換されるデータ項目を示すために使用できる。これは、規定的ではない<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<span class="mark">Property</span>が読み取りと書き込みで異なるデータを示す場合の回避策として使用でき、それは、<span class="mark">Thing Description</span>で既存のデバイスまたはサービスを拡張する場合に当てはまる。</p>
 
-<p><code>readOnly</code>と<code>writeOnly</code>を用いたTDの断片を以下に示します。</p>
+<p><code>readOnly</code>と<code>writeOnly</code>を用いたTDの断片を以下に示す。</p>
 
 <div class="example" id="example-26">
 <div class="marker"><a class="self-link" href="#example-26">例<bdi>26</bdi></a></div>
@@ -3688,9 +3693,9 @@
 ...</code></pre>
 </div>
 
-<p><code>status</code>プロパティーが読み取られると、ペイロードの<code>latestStatus</code>メンバーを用いて状態のデータが返されます。<code>status</code>プロパティーを更新するには、ペイロードの<code>newStatusValue</code>メンバーを通じて新しい値を提供しなければなりません。</p>
+<p><code>status</code> <span class="mark">Property</span>が読み取られると、ペイロードの<code>latestStatus</code>メンバーを用いて状態のデータが返される。<code>status</code> <span class="mark">Property</span>を更新するには、ペイロードの<code>newStatusValue</code>メンバーを通じて新しい値を提供しなければならない。</p>
 
-<p>追加機能として、モノの記述インスタンスにより、データ・スキーマ内で<code>unit</code>メンバーを使用できるようになります。これを使用して、測定単位をデータ項目に関連付けることができます。その文字列の値は自由に選択できます。しかし、よく知られている<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>で定義されている単位を選択することをお勧めします。例に関しては、<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>を参照してください。</p>
+<p>追加機能として、<span class="mark">Thing Description</span>インスタンスにより、データスキーマ内で<code>unit</code>メンバーを使用できるようになる。これを使用して、測定単位をデータ項目に関連付けることができる。その文字列の値は自由に選択できる。しかし、よく知られている<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>で定義されている単位を選択することをお勧めする。例に関しては、<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>を参照していただきたい。</p>
 
 </section>
 </section>
@@ -3698,21 +3703,21 @@
 
 <h3 id="x6-4-identification"><bdi class="secno">6.4</bdi> 識別<a class="self-link" aria-label="§" href="#identification"></a></h3>
 
-<p>モノの記述のJSONベースのシリアル化は、<code>application/td+json</code>というメディア・タイプまたは<code>432</code>というCoAPコンテンツ形式IDによって識別されます(<a href="#iana-section" class="sec-ref">§&nbsp;<bdi class="secno">10.</bdi> IANAに関する留意点</a>を参照)。</p>
+<p><span class="mark">Thing Description</span>のJSONベースの<span class="mark">シリアライゼーション</span>は、<code>application/td+json</code>というメディアタイプまたは<code>432</code>というCoAPコンテンツ形式IDによって識別される(<a href="#iana-section" class="sec-ref">§&nbsp;<bdi class="secno">10.</bdi> IANAに関する留意点</a>を参照)。</p>
 
-    </section>
-  </section>
-  <section id="sec-context-extensions" class="informative">
+</section>
+</section>
+<section id="sec-context-extensions" class="informative">
 
 <h2 id="x7-td-context-extensions"><bdi class="secno">7.</bdi> TDコンテキスト拡張<a class="self-link" aria-label="§" href="#sec-context-extensions"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
-<p><a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>の標準的な<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の定義に加えて、WoTモノの記述は追加の名前空間からコンテキストの知識を追加する可能性を提供します。このメカニズムを用いて、追加の(例えば、ドメイン固有の)セマンティクスでモノの記述のインスタンスを充実させることができます。また、将来的に追加の<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>や新しいセキュリティ・スキームをインポートするためにも使用できます。</p>
+<p><a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>の標準的な<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の定義に加えて、<span class="mark">WoT Thing Description</span>は追加の名前空間からコンテキストの知識を追加する可能性を提供する。このメカニズムを用いて、追加の(例えば、ドメイン固有の)セマンティクスで<span class="mark">Thing Description</span>のインスタンスを充実させることができる。また、将来的に追加の<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>や新しいセキュリティスキームをインポートするためにも使用できる。</p>
 
-<p>そのような<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>の場合、モノの記述はJSON-LD[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]で知られている<code>@context</code>メカニズムを用います。<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いる場合、<code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<code>@context</code>の値は、JSON-LDコンテキスト・ファイルを識別する<code>anyURI</code>型の追加要素を持つ配列か、<a href="#thing" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1.1</bdi> <code>Thing</code>(モノ)</a>で定義している名前空間IRIを含んでいる<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>です。</p>
+<p>そのような<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>の場合、<span class="mark">Thing Description</span>はJSON-LD[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]で知られている<code>@context</code>メカニズムを用いる。<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いる場合、<code>Thing</code>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<code>@context</code>の値は、JSON-LDコンテキストファイルを識別する<code>anyURI</code>型の追加要素を持つ配列か、<a href="#thing" class="sec-ref">§&nbsp;<bdi class="secno">5.3.1.1</bdi> <code>Thing</code></a>で定義している名前空間IRIを含んでいる<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a>である。</p>
 
-<p><a href="#td-basic-types-mapping" class="sec-ref">§&nbsp;<bdi class="secno">6.1</bdi> JSONの型へのマッピング</a>の複合型のシリアル化規則は、拡張された<code>@context</code>名前-値のペアのシリアル化を定義します。<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>の断片を以下に示します。</p>
+<p><a href="#td-basic-types-mapping" class="sec-ref">§&nbsp;<bdi class="secno">6.1</bdi> JSONの型へのマッピング</a>の複合型の<span class="mark">シリアライゼーション</span>規則は、拡張された<code>@context</code>名前-値のペアの<span class="mark">シリアライゼーション</span>を定義する。<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>の断片を以下に示す。</p>
 
 <div class="example" id="example-27">
 <div class="marker"><a class="self-link" href="#example-27">例<bdi>27</bdi></a></div>
@@ -3732,12 +3737,11 @@
 
 <h3 id="x7-1-semantic-annotations"><bdi class="secno">7.1</bdi> セマンティックなアノテーション<a class="self-link" aria-label="§" href="#semantic-annotations"></a></h3>
 
-<p><a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>により、モノの記述インスタンスに<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を追加できます。含まれている名前空間が、RDFスキーマやOWLによって提供されるものなどの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義に基づいている場合、インスタンスをそのような外部の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義に関連付けることにより、モノの記述の任意の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスにセマンティックにアノテーションを付与するためにそれを使用できます。これは、<code>@type</code>の名前-値のペアに<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名を割り当てるか、複数の関連付け/アノテーションの<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>の値に<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名を含めることによって行われます。<a href="#td-basic-types-mapping" class="sec-ref">§&nbsp;<bdi class="secno">6.1</bdi> JSONの型へのマッピング</a>のシリアル化規則に従って、<code>@type</code>はJSON文字列かJSON配列としてシリアル化されます。
-<code>@type</code>は、ノードの型を設定するために用いられるJSON-LDキーワード[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]です。</p>
+<p><a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>により、<span class="mark">Thing Description</span>インスタンスに<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を追加できる。含まれている名前空間が、RDFスキーマやOWLによって提供されるものなどの<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義に基づいている場合、インスタンスをそのような外部の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>定義に関連付けることにより、<span class="mark">Thing Description</span>の任意の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンスにセマンティックにアノテーションを付与するためにそれを使用できる。これは、<code>@type</code>の名前-値のペアに<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名を割り当てるか、複数の関連付け/アノテーションの<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>の値に<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>名を含めることによって行われる。<a href="#td-basic-types-mapping" class="sec-ref">§&nbsp;<bdi class="secno">6.1</bdi> JSONの型へのマッピング</a>の<span class="mark">シリアライゼーション</span>規則に従って、<code>@type</code>はJSON文字列かJSON配列として<span class="mark">シリアライズ</span>される。<code>@type</code>は、ノードの型を設定するために用いられるJSON-LDキーワード[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]である。</p>
 
-<p><a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>により、モノの記述の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内に追加の名前-値のペアと明確に定義された値を含めることもできます。このペアと値は、含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を通じて定義され、それぞれ対応するJSONオブジェクトの追加メンバーまたは既存のメンバーの値としてシリアル化されます。例は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の追加バージョンのメタデータまたはデータ・アイテムの測定単位です。</p>
+<p><a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>により、<span class="mark">Thing Description</span>の<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>のインスタンス内に追加の名前-値のペアと明確に定義された値を含めることもできる。このペアと値は、含まれている<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を通じて定義され、それぞれ対応するJSONオブジェクトの追加メンバーまたは既存のメンバーの値として<span class="mark">シリアライズ</span>される。例は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の追加バージョンのメタデータまたはデータアイテムの測定単位である。</p>
 
-<p>例として、以下に示すTDの断片は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のハードウェアとファームウェアのバージョン番号を追加することでバージョン情報のコンテナを拡張し、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>とデータ・スキーマの単位に外部<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の値を用いています。<a href="https://w3id.org/saref">SAREF</a>は<a href="#thing-description-full-serialization" class="box-ref">例<bdi>2</bdi></a>でも用いており、<a href="http://www.ontology-of-units-of-measure.org/resource/om-2/">OM</a>は測定単位のオントロジー[<cite><a class="bibref" data-link-type="biblio" href="#bib-rijgersberg" title="Ontology of Units of Measure and Related Concepts">RIJGERSBERG</a></cite>]です。これらの<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は例として用いています。 &#x2014; 特にホーム・オートメーションの領域には他の語彙が存在している場合があります。</p>
+<p>例として、以下に示すTDの断片は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のハードウェアとファームウェアのバージョン番号を追加することでバージョン情報のコンテナを拡張し、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>とデータスキーマの単位に外部<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>の値を用いている。<a href="https://w3id.org/saref">SAREF</a>は<a href="#thing-description-full-serialization" class="box-ref">例<bdi>2</bdi></a>でも用いており、<a href="http://www.ontology-of-units-of-measure.org/resource/om-2/">OM</a>は測定単位のオントロジー[<cite><a class="bibref" data-link-type="biblio" href="#bib-rijgersberg" title="Ontology of Units of Measure and Related Concepts">RIJGERSBERG</a></cite>]である。これらの<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>は例として用いている。 &#x2014; 特にホームオートメーションの領域には他の語彙が存在している場合がある。</p>
 
 <div class="example" id="example-28">
 <div class="marker"><a class="self-link" href="#example-28">例<bdi>28</bdi></a></div>
@@ -3772,9 +3776,9 @@
 }</code></pre>
 </div>
 
-<p>多くの場合、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いて、データ・スキーマの一部にアノテーションを付与し、物理世界のオブジェクトの状態情報をセマンティックに処理できます。これは、対話中に交換されるデータによって表されます(例えば、応答のペイロードで)。例えば、RDFのこの状態情報のセマンティックな記述は、<a href="#dfn-td-document" class="internalDFN" data-link-type="dfn">TDドキュメント</a>に埋め込むことができ、データ・スキーマの部分は、物理世界のオブジェクトのRDFでモデル化された状態の特定の部分を参照するように個々にアノテーションを付与することができます。</p>
+<p>多くの場合、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いて、データスキーマの一部にアノテーションを付与し、物理世界のオブジェクトの状態情報をセマンティックに処理できる。これは、相互作用中に交換されるデータによって表される(例えば、応答のペイロードで)。例えば、RDFのこの状態情報のセマンティックな記述は、<a href="#dfn-td-document" class="internalDFN" data-link-type="dfn">TDドキュメント</a>に埋め込むことができ、データスキーマの部分は、物理世界のオブジェクトのRDFでモデル化された状態の特定の部分を参照するように個々にアノテーションを付与することができる。</p>
 
-<p>以下のTDの断片では、SAREFを用いて照明の状態を記述しています。<a href="https://www.w3.org/TR/vocab-ssn/">SSN</a>(セマンティック・センサー・ネットワーク・オントロジー[<cite><a class="bibref" data-link-type="biblio" href="#bib-vocab-ssn" title="Semantic Sensor Network Ontology">VOCAB-SSN</a></cite>])から取得した外部の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である<code>ssn:forProperty</code>は、<code>status</code><a href="#dfn-property" class="internalDFN" data-link-type="dfn">プロパティー</a>のデータ・スキーマを物理世界のオブジェクトの実際のオン/オフ状態にリンクするために用いられています。</p>
+<p>以下のTDの断片では、SAREFを用いて照明の状態を記述している。<a href="https://www.w3.org/TR/vocab-ssn/">SSN</a>(セマンティックセンサーネットワークオントロジー[<cite><a class="bibref" data-link-type="biblio" href="#bib-vocab-ssn" title="Semantic Sensor Network Ontology">VOCAB-SSN</a></cite>])から取得した外部の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>である<code>ssn:forProperty</code>は、<code>status</code> <a href="#dfn-property" class="internalDFN" data-link-type="dfn"><span class="mark">Property</span></a>のデータスキーマを物理世界のオブジェクトの実際のオン/オフ状態にリンクするために用いられている。</p>
 
 <div class="example" id="saref-state-annotation-example">
 <div class="marker"><a class="self-link" href="#saref-state-annotation-example">例<bdi>29</bdi></a></div>
@@ -3815,16 +3819,16 @@
 }</code></pre>
 </div>
 
-<p><a href="#thing-description-full-serialization" class="box-ref">例<bdi>2</bdi></a>では、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の状態は、<code>status</code>アフォーダンス自体によって示され、可能な状態の変化は<code>toggle</code>アフォーダンスによって示されています。言い換えれば、物理世界のオブジェクトの状態は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>を直接提供します。この設計は、シンプルな場合には満足のいくものです。しかし、より複雑なケースでは、同じ物理的な状態に対していくつかのアフォーダンスが利用できる場合があります。上記の例では、<code>fullStatus</code><a href="#dfn-property" class="internalDFN" data-link-type="dfn">プロパティー</a>で、照明の状態のより詳細な別の表現を提供しています。</p>
+<p><a href="#thing-description-full-serialization" class="box-ref">例<bdi>2</bdi></a>では、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の状態は、<code>status</code>アフォーダンス自体によって示され、可能な状態の変化は<code>toggle</code>アフォーダンスによって示されている。言い換えれば、物理世界のオブジェクトの状態は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>を直接提供する。この設計は、シンプルな場合には満足のいくものである。しかし、より複雑なケースでは、同じ物理的な状態に対していくつかのアフォーダンスが利用できる場合がありる。上記の例では、<code>fullStatus</code> <a href="#dfn-property" class="internalDFN" data-link-type="dfn"><span class="mark">Property</span></a>で、照明の状態のより詳細な別の表現を提供している。</p>
 
 </section>
 <section id="adding-protocol-bindings">
 
-<h3 id="x7-2-adding-protocol-bindings"><bdi class="secno">7.2</bdi> プロトコル・バインディングの追加<a class="self-link" aria-label="§" href="#adding-protocol-bindings"></a></h3>
+<h3 id="x7-2-adding-protocol-bindings"><bdi class="secno">7.2</bdi> プロトコルバインディングの追加<a class="self-link" aria-label="§" href="#adding-protocol-bindings"></a></h3>
 
-<p>モノの記述で<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いると、通信メタデータを補完したり、<code>Form</code>インスタンスを表すJSONオブジェクトにシリアル化された追加の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を通じて新しい<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>を追加することができます。(<a href="#protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">8.3</bdi> プロトコル・バインディング</a>も参照)。</p>
+<p><span class="mark">Thing Description</span>で<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いると、通信メタデータを補完したり、<code>Form</code>インスタンスを表すJSONオブジェクトに<span class="mark">シリアライズ</span>された追加の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を通じて新しい<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>を追加することができる。(<a href="#protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">8.3</bdi> プロトコルバインディング</a>も参照)。</p>
 
-<p>この仕様の執筆時点では、そのような<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>は利用できないため、次のTDの例では、架空のCoAPの<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>を用いています。この<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>は、例の名前空間<code>http://www.example.org/coap-binding#</code>からアクセスできる<em>RDF 1.0のHTTP語彙</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-http-in-rdf10" title="HTTP Vocabulary in RDF 1.0">HTTP-in-RDF10</a></cite>]に似た<em>RDF語彙のCoAP</em>があると仮定しています。補足された<code>cov:methodName</code>メンバーは、どのCoAPメソッドを適用しなければならないかを<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>に指示します(例えば、CoAPメソッド・コード0.01には<code>GET</code>、CoAPメソッド・コード0.02には<code>POST</code>、またはCoAPメソッド・コード0.07には<code>iPATCH</code>)。</p>
+<p>この仕様の執筆時点では、そのような<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>は利用できないため、次のTDの例では、架空のCoAPの<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>を用いている。この<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>は、例の名前空間<code>http://www.example.org/coap-binding#</code>からアクセスできる<em>RDF 1.0のHTTP語彙</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-http-in-rdf10" title="HTTP Vocabulary in RDF 1.0">HTTP-in-RDF10</a></cite>]に似た<em>RDF語彙のCoAP</em>があると仮定している。補足された<code>cov:methodName</code>メンバーは、どのCoAPメソッドを適用しなければならないかを<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に指示する(例えば、CoAPメソッドコード0.01には<code>GET</code>、CoAPメソッドコード0.02には<code>POST</code>、またはCoAPメソッドコード0.07には<code>iPATCH</code>)。</p>
 
 <aside class="example" id="context-extension-for-forms">
 <div class="marker"><a class="self-link" href="#context-extension-for-forms">例<bdi>30</bdi></a><span class="example-title">: TDコンテキスト拡張を介したフォームの特殊化</span></div>
@@ -3858,9 +3862,9 @@
     </section>
     <section id="adding-security-schemes">
 
-<h3 id="x7-3-adding-security-schemes"><bdi class="secno">7.3</bdi> セキュリティ・スキームの追加<a class="self-link" aria-label="§" href="#adding-security-schemes"></a></h3>
+<h3 id="x7-3-adding-security-schemes"><bdi class="secno">7.3</bdi> セキュリティスキームの追加<a class="self-link" aria-label="§" href="#adding-security-schemes"></a></h3>
 
-<p>最後に、<a href="#sec-security-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義</a>に含まれていない新しいセキュリティ・スキームは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のメカニズムを用いてインポートできます。この例では、[<cite><a class="bibref" data-link-type="biblio" href="#bib-ace" title="Authentication and Authorization for Constrained Environments (ACE) using the OAuth 2.0 Framework (ACE-OAuth)">ACE</a></cite>]に基づく架空のACEセキュリティ・スキームを用いており、それは、この例では、<code>http://www.example.org/ace-security#</code>の名前空間で定義されています。このような追加のセキュリティ・スキームは、<a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>でなければならないことに注意してください。</p>
+<p>最後に、<a href="#sec-security-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義</a>に含まれていない新しいセキュリティスキームは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のメカニズムを用いてインポートできる。この例では、[<cite><a class="bibref" data-link-type="biblio" href="#bib-ace" title="Authentication and Authorization for Constrained Environments (ACE) using the OAuth 2.0 Framework (ACE-OAuth)">ACE</a></cite>]に基づく架空のACEセキュリティスキームを用いており、それは、この例では、<code>http://www.example.org/ace-security#</code>の名前空間で定義されている。このような追加のセキュリティスキームは、<a href="#securityscheme" class="sec-ref"><code>SecurityScheme</code></a>という<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>でなければならないことに注意していただきたい。</p>
 
 <div class="example" id="example-31">
 <div class="marker"><a class="self-link" href="#example-31">例<bdi>31</bdi></a></div>
@@ -3912,7 +3916,7 @@
 }</code></pre>
 </div>
 
-<p><a href="#sec-security-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義</a>で定義しているすべてのセキュリティ・スキームは既にTDコンテキストの一部であり、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を介して含める必要はありません。</p>
+<p><a href="#sec-security-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.3</bdi> セキュリティ語彙の定義</a>で定義しているすべてのセキュリティスキームは既にTDコンテキストの一部であり、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を介して含める必要はない。</p>
 
 </section>
 </section>
@@ -3920,59 +3924,59 @@
 
 <h2 id="x8-behavioral-assertions"><bdi class="secno">8.</bdi> 動作の言明<a class="self-link" aria-label="§" href="#behavior"></a></h2>
 
-<p>以下の言明は、TDの表現や情報モデルとは対照的に、WoTシステムの構成要素の動作に関連しています。しかし、TDは記述的であり、特に既存のネットワーク・インターフェースを記述するために用いられる場合があることに注意してください。これらの場合、そのような既存のインターフェースの動作を制限する言明を作成することはできません。代わりに、言明は、そのようなインターフェースを正確に表すためのTDの制約と解釈されなければなりません。</p>
+<p>以下の言明は、TDの表現や情報モデルとは対照的に、WoTシステムの構成要素の動作に関連している。しかし、TDは記述的であり、特に既存のネットワークインターフェースを記述するために用いられる場合があることに注意していただきたい。これらの場合、そのような既存のインターフェースの動作を制限する言明を作成することはできない。代わりに、言明は、そのようなインターフェースを正確に表すためのTDの制約と解釈されなければならない。</p>
 
 <section id="behavior-security">
 
-<h3 id="x8-1-security-configurations"><bdi class="secno">8.1</bdi> セキュリティの設定<a class="self-link" aria-label="§" href="#behavior-security"></a></h3>
+<h3 id="x8-1-security-configurations"><bdi class="secno">8.1</bdi> <span class="mark">セキュリティ<span class="mark">構成情報</span></span><a class="self-link" aria-label="§" href="#behavior-security"></a></h3>
 
-<p>安全な相互運用を可能にするために、セキュリティ設定は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の要件を正確に反映しなければなりません。</p>
+<p>安全な相互運用を可能にするために、セキュリティ<span class="mark">構成情報</span>は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の要件を正確に反映しなければならない。</p>
 
 <ul>
-  <li><span class="rfc2119-assertion" id="td-security-binding"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が対話のために特定のアクセス・メカニズムを必要とする場合、モノの記述のセキュリティの設定でそのメカニズムを指定しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="td-security-no-extras"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が対話のために特定のアクセス・メカニズムを必要としない場合、モノの記述のセキュリティ設定でそのメカニズムを指定してはならない(<em class="rfc2119" title="MUST NOT">MUST NOT</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-security-binding"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が相互作用のために特定のアクセスメカニズムを必要とする場合、<span class="mark">Thing Description</span>のセキュリティ<span class="mark">構成情報</span>でそのメカニズムを指定しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="td-security-no-extras"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が相互作用のために特定のアクセスメカニズムを必要としない場合、<span class="mark">Thing Description</span>のセキュリティ<span class="mark">構成情報</span>でそのメカニズムを指定してはならない(<em class="rfc2119" title="MUST NOT">MUST NOT</em>)。</span></li>
 </ul>
 
-一部のセキュリティ・プロトコルでは、必要なエンコーディングや暗号化スキームなど、認証情報を動的に要求する場合があります。上記の結果の1つは、プロトコルが、モノの記述で宣言されていないセキュリティ認証情報の形式、またはエンコーディングや暗号化スキームを要求する場合、モノの記述は無効と見なされるということです。
+一部のセキュリティプロトコルでは、必要なエンコーディングや暗号化スキームなど、認証情報を動的に要求する場合がある。上記の結果の1つは、プロトコルが、<span class="mark">Thing Description</span>で宣言されていないセキュリティ認証情報の形式、またはエンコーディングや暗号化スキームを要求する場合、<span class="mark">Thing Description</span>は無効と見なされるということである。
 
 </section>
 <section id="behavior-data">
 
-<h3 id="x8-2-data-schemas"><bdi class="secno">8.2</bdi>データ・スキーマ<a class="self-link" aria-label="§" href="#behavior-data"></a></h3>
+<h3 id="x8-2-data-schemas"><bdi class="secno">8.2</bdi> <span class="mark">Data Schema</span><a class="self-link" aria-label="§" href="#behavior-data"></a></h3>
 
-<p>TDで提供されるデータ・スキーマは、TDで指定されている対話で記述されている<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>によって返され、受け入れられるデータ・ペイロードを正確に表すべきです。一般的に、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>はWoTモノの記述で示されていないものは生成せず、データ・スキーマに厳密に従うべきですが、WoTモノの記述で明示的に指定されていない<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>からの追加データは受け入れるべきです。一般的に、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>はWoTモノの記述によって<em>記述</em>されますが、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と対話するときにWoTモノの記述に従うように<em>制約</em>されます。</p>
+<p>TDで提供されるデータスキーマは、TDで指定されている相互作用で記述されている<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>によって返され、受け入れられるデータペイロードを正確に表すべきである。一般的に、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>は<span class="mark">WoT Thing Description</span>で示されていないものは生成せず、データスキーマに厳密に従うべきだが、<span class="mark">WoT Thing Description</span>で明示的に指定されていない<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>からの追加データは受け入れるべきである。一般的に、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は<span class="mark">WoT Thing Description</span>によって<em>記述</em>されるが、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と相互作用するときに<span class="mark">WoT Thing Description</span>に従うように<em>制約</em>される。</p>
 
 <ul>
-  <li><span class="rfc2119-assertion" id="client-data-schema">WoTモノの記述で記述されている別のターゲットの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と対話するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、対応する対話で指定されているデータ・スキーマに従って編成されたデータを生成しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="server-data-schema">WoTモノの記述は、個々の対話によって返され、受け入れられるデータを正確に記述しなければならない<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="server-data-schema-extras"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、対話から追加のデータを、そのようなデータがWoTモノの記述で示されているデータ・スキーマに記述されていない場合でも返すことができる(<em class="rfc2119" title="MAY">MAY</em>)。</span>これは、返されるデータに追加のプロパティーやアイテムがある可能性がある<code>ObjectSchema</code>と<code>ArraySchema</code>(<code>items</code>が<code>DataSchema</code>の配列である場合)に適用される。これは、[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている<code>"additionalProperties":true</code>や<code>"additionalItems":true</code>であるかのように動作する。</li>
-  <li><span class="rfc2119-assertion" id="client-data-schema-accept-extras">別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と対話するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、ターゲットの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のモノの記述で示されているデータ・スキーマに記述されていない追加データをエラーなしに受け入れなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>これは、返されるデータに追加のプロパティーやアイテムがある可能性がある<code>ObjectSchema</code>と<code>ArraySchema</code>(<code>items</code>が<code>DataSchema</code>の配列である場合)に適用される。これは、[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている<code>"additionalProperties":true</code>や<code>"additionalItems":true</code>であるかのように動作する。</li>
-  <li><span class="rfc2119-assertion" id="client-data-schema-no-extras">別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と対話するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、その<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のモノの記述で示されているデータ・スキーマに記述されていないデータを生成してはならない(<em class="rfc2119" title="MUST NOT">MUST NOT</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="client-uri-template">別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と対話するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、ターゲットの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のモノの記述で示されているURIテンプレート、基底URI、およびフォームのhrefパラメータに従ってURIを生成しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="server-uri-template">WoTモノの記述のURIテンプレート、基底URI、およびhrefメンバーは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の<a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn">WoTインターフェース</a>を正確に記述しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="client-data-schema"><span class="mark">WoT Thing Description</span>で記述されている別のターゲットの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と相互作用するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は、対応する相互作用で指定されているデータスキーマに従って編成されたデータを生成しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="server-data-schema"><span class="mark">WoT Thing Description</span>は、個々の相互作用によって返され、受け入れられるデータを正確に記述しなければならない<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="server-data-schema-extras"><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は、相互作用から追加のデータを、そのようなデータが<span class="mark">WoT Thing Description</span>で示されているデータスキーマに記述されていない場合でも返すことができる(<em class="rfc2119" title="MAY">MAY</em>)。</span>これは、返されるデータに追加のプロパティーやアイテムがある可能性がある<code>ObjectSchema</code>と<code>ArraySchema</code>(<code>items</code>が<code>DataSchema</code>の配列である場合)に適用される。これは、[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている<code>"additionalProperties":true</code>や<code>"additionalItems":true</code>であるかのように動作する。</li>
+  <li><span class="rfc2119-assertion" id="client-data-schema-accept-extras">別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と相互作用するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は、ターゲットの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<span class="mark">Thing Description</span>で示されているデータスキーマに記述されていない追加データをエラーなしに受け入れなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span>これは、返されるデータに追加のプロパティーやアイテムがある可能性がある<code>ObjectSchema</code>と<code>ArraySchema</code>(<code>items</code>が<code>DataSchema</code>の配列である場合)に適用される。これは、[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]で定義されている<code>"additionalProperties":true</code>や<code>"additionalItems":true</code>であるかのように動作する。</li>
+  <li><span class="rfc2119-assertion" id="client-data-schema-no-extras">別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と相互作用するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は、その<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<span class="mark">Thing Description</span>で示されているデータスキーマに記述されていないデータを生成してはならない(<em class="rfc2119" title="MUST NOT">MUST NOT</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="client-uri-template">別の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と相互作用するときに<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>の役割を果たす<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は、ターゲットの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<span class="mark">Thing Description</span>で示されているURIテンプレート、基底URI、およびフォームのhrefパラメータに従ってURIを生成しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="server-uri-template"><span class="mark">WoT Thing Description</span>のURIテンプレート、基底URI、およびhrefメンバーは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<a href="#dfn-wot-interface" class="internalDFN" data-link-type="dfn">WoT インターフェース</a>を正確に記述しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
 </ul>
 
 </section>
 <section id="protocol-bindings">
 
-<h3 id="x8-3-protocol-bindings"><bdi class="secno">8.3</bdi> プロトコル・バインディング<a class="self-link" aria-label="§" href="#protocol-bindings"></a></h3>
+<h3 id="x8-3-protocol-bindings"><bdi class="secno">8.3</bdi> プロトコルバインディング<a class="self-link" aria-label="§" href="#protocol-bindings"></a></h3>
 
-<p><a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>は、<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>から、HTTP[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7231" title="Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content">RFC7231</a></cite>]、CoAP[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>]、MQTT[<cite><a class="bibref" data-link-type="biblio" href="#bib-mqtt" title="MQTT Version 3.1.1">MQTT</a></cite>]などの特定のプロトコルの具体的なメッセージへのマッピングです。<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn">対話アフォーダンス</a>の<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している<code>forms</code>としてシリアル化されます。</p>
+<p><a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>は、<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>から、HTTP[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7231" title="Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content">RFC7231</a></cite>]、CoAP[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>]、MQTT[<cite><a class="bibref" data-link-type="biblio" href="#bib-mqtt" title="MQTT Version 3.1.1">MQTT</a></cite>]などの特定のプロトコルの具体的なメッセージへのマッピングである。<a href="#dfn-interaction-affordance" class="internalDFN" data-link-type="dfn"><span class="mark">相互作用のアフォーダンス</span></a>の<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>は、<a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>で定義している<code>forms</code>として<span class="mark">シリアライズ</span>される。</p>
 
-<p>WoTモノの記述のすべてのフォームには、<code>href</code>メンバーで示される送信ターゲットがなければなりません。この送信ターゲットのURIスキームは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>がどのような<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>を実装しているかを示します[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]。例えば、ターゲットが<code>http</code>または<code>https</code>で始まっていれば、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>がHTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>を実装していることを推測でき、フォームのインスタンスにおいてHTTP固有の用語を予期すべきです(次の項、<a href="#http-binding-assertions" class="sec-ref">§&nbsp;<bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコル・バインディング</a>を参照してください)。</p>
+<p><span class="mark">WoT Thing Description</span>のすべてのフォームには、<code>href</code>メンバーで示される送信ターゲットがなければならない。この送信ターゲットのURIスキームは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>がどのような<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>を実装しているかを示す[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WOT-ARCHITECTURE</a></cite>]。例えば、ターゲットが<code>http</code>または<code>https</code>で始まっていれば、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>がHTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>を実装していることを推測でき、フォームのインスタンスにおいてHTTP固有の用語を予期すべきである(次の項、<a href="#http-binding-assertions" class="sec-ref">§&nbsp;<bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコルバインディング</a>を参照)。</p>
 
 <ul>
-  <li><span class="rfc2119-assertion" id="bindings-requirements-scheme">WoTモノの記述のすべてのフォームは、その<code>href</code>メンバーのURIスキームによって示される<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>の要件に従わなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
-  <li><span class="rfc2119-assertion" id="bindings-server-accept">WoTモノの記述のすべてのフォームは、対話で<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が受け入れるリクエスト(リクエスト・ヘッダーが存在する場合は、それを含む)を正確に記述しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="bindings-requirements-scheme"><span class="mark">WoT Thing Description</span>のすべてのフォームは、その<code>href</code>メンバーのURIスキームによって示される<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>の要件に従わなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
+  <li><span class="rfc2119-assertion" id="bindings-server-accept"><span class="mark">WoT Thing Description</span>のすべてのフォームは、相互作用で<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が受け入れるリクエスト(リクエストヘッダーが存在する場合は、それを含む)を正確に記述しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></li>
 </ul>
 
 <section id="http-binding-assertions">
 
-<h4 id="x8-3-1-protocol-binding-based-on-http"><bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコル・バインディング<a class="self-link" aria-label="§" href="#http-binding-assertions"></a></h4>
+<h4 id="x8-3-1-protocol-binding-based-on-http"><bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコルバインディング<a class="self-link" aria-label="§" href="#http-binding-assertions"></a></h4>
 
-<p>デフォルトでは、モノの記述は、<em>RDF 1.0のHTTP語彙</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-http-in-rdf10" title="HTTP Vocabulary in RDF 1.0">HTTP-in-RDF10</a></cite>]からのHTTP RDF語彙の定義を含めることにより、HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>をサポートします。この語彙は、<code>http://www.w3.org/2011/http#</code>を指し示す接頭辞である<code>htv</code>を用いることで、TDのインスタンス内で直接使用できます。HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>の詳細は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]にあります。</p>
+<p>デフォルトでは、<span class="mark">Thing Description</span>は、<em>RDF 1.0のHTTP語彙</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-http-in-rdf10" title="HTTP Vocabulary in RDF 1.0">HTTP-in-RDF10</a></cite>]からのHTTP RDF語彙の定義を含めることにより、HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>をサポートする。この語彙は、<code>http://www.w3.org/2011/http#</code>を指し示す接頭辞である<code>htv</code>を用いることで、TDのインスタンス内で直接使用できる。HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>の詳細は、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]にある。</p>
 
-<p>HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>を実装する<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>と対話するために、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>は、フォームを送信するときにどのHTTPメソッドを用いるべきかを知る必要があります。一般的なケースでは、モノの記述には、メソッドを示す用語、つまり<code>htv:methodName</code>を明示的に含めることができます。簡潔にするために、HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>は、下記の操作型の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を定義し、これは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が期待するメソッド(例えば、読み取りにGET、書き込みにPUT)の収束を目的としています。<span class="rfc2119-assertion" id="td-default-http-method">HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>を表している形式でメソッドが示されていない場合、次の表で示している<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を想定しなければなりません(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p>HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>を実装する<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>と相互作用するために、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>は、フォームを送信するときにどのHTTPメソッドを用いるべきかを知る必要がある。一般的なケースでは、<span class="mark">Thing Description</span>には、メソッドを示す用語、つまり<code>htv:methodName</code>を明示的に含めることができる。簡潔にするために、HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>は、下記の操作型の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を定義し、これは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が期待するメソッド(例えば、読み取りにGET、書き込みにPUT)の収束を目的としている。<span class="rfc2119-assertion" id="td-default-http-method">HTTPに基づく<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>を表している形式でメソッドが示されていない場合、次の表で示している<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を想定しなければならない(<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 <table class="def">
 <thead>
@@ -4001,11 +4005,11 @@
 </tbody>
 </table>
 
-<p>例えば、<a href="#introduction" class="sec-ref">§&nbsp;<bdi class="secno">1.</bdi> はじめに</a>の<a href="#simple-thing-description-sample">例1</a>では、フォームに操作型とHTTPメソッドが含まれていません。<a href="#simple-thing-description-sample">例1</a>のフォームでは、次の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を想定すべきです。</p>
+<p>例えば、<a href="#introduction" class="sec-ref">§&nbsp;<bdi class="secno">1.</bdi> はじめに</a>の<a href="#simple-thing-description-sample">例1</a>では、フォームに操作型とHTTPメソッドが含まれていない。<a href="#simple-thing-description-sample">例1</a>のフォームでは、次の<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を想定すべきである。</p>
 
 <aside class="example with-default" id="example-32">
 <div class="marker"><a class="self-link" href="#example-32">例<bdi>32</bdi></a></div>
-<div class="with-default-control"><input type="checkbox"> <span><i>with default values for Protocol Binding based on HTTP</i></span></div>
+<div class="with-default-control"><input type="checkbox"> <span><i>HTTPに基づくプロトコルバインディングでデフォルト値を使用</i></span></div>
 <pre aria-busy="false"><code class="hljs json">{
     <span class="hljs-attr">"@context"</span>: <span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>,
     <span class="hljs-attr">"id"</span>: <span class="hljs-string">"urn:dev:ops:32473-WoTLamp-1234"</span>,
@@ -4112,11 +4116,11 @@
 </section>
 <section id="other-protocol-bindings">
 
-<h4 id="x8-3-2-other-protocol-bindings"><bdi class="secno">8.3.2</bdi> その他のプロトコル・バインディング<a class="self-link" aria-label="§" href="#other-protocol-bindings"></a></h4>
+<h4 id="x8-3-2-other-protocol-bindings"><bdi class="secno">8.3.2</bdi> その他のプロトコルバインディング<a class="self-link" aria-label="§" href="#other-protocol-bindings"></a></h4>
 
-<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が実装できる<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>の数には制限はありません。その他の<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>(例えば、CoAP、MQTT、またはOPC UAなどの)は、<em>RDF 1.0のHTTP語彙</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-http-in-rdf10" title="HTTP Vocabulary in RDF 1.0">HTTP-in-RDF10</a></cite>]に似たプロトコル<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>や<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>の定義が含まれている仕様などの別のドキュメントで標準化される予定です。このようなプロトコルは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のメカニズムを用いることで、簡単にTDに統合できます(<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>を参照)。</p>
+<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が実装できる<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>の数には制限はない。その他の<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>(例えば、CoAP、MQTT、またはOPC UAなどの)は、<em>RDF 1.0のHTTP語彙</em>[<cite><a class="bibref" data-link-type="biblio" href="#bib-http-in-rdf10" title="HTTP Vocabulary in RDF 1.0">HTTP-in-RDF10</a></cite>]に似たプロトコル<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>や<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>の定義が含まれている仕様などの別のドキュメントで標準化される予定である。このようなプロトコルは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>のメカニズムを用いることで、簡単にTDに統合できる(<a href="#sec-context-extensions" class="sec-ref">§&nbsp;<bdi class="secno">7.</bdi> TDコンテキスト拡張</a>を参照)。</p>
 
-<p>IoTプラットフォームとエコシステムを記述する方法については、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]を参照してください。</p>
+<p><span class="mark">IoTプラットフォーム</span>とエコシステムを記述する方法については、[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WOT-BINDING-TEMPLATES</a></cite>]を参照していただきたい。</p>
 
 </section>
 </section>
@@ -4125,23 +4129,23 @@
 
 <h2 id="x9-security-and-privacy-considerations"><bdi class="secno">9.</bdi> セキュリティとプライバシーに関する留意点<a class="self-link" aria-label="§" href="#sec-security-consideration"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
-<p>一般的に、WoTシステムを保護するために講じられるセキュリティ対策は、システムが直面する可能性のある脅威と攻撃者、および保護する必要がある資産の価値に依存します。さらに、プライバシーのリスクは、モノと特定可能な人物との関連性、および直接的な情報とそのような関連性から入手可能な推測される情報の両方に依存します。様々な状況に適応できる脅威モデルを含む、モノのウェブのセキュリティとプライバシーに関する留意点の詳細な議論は、参考情報のドキュメント[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-security-guidelines" title="Web of Things (WoT) Security and Privacy Guidelines">WOT-SECURITY-GUIDELINES</a></cite>]に記載されています。この項では、WoTモノの記述に直接関連するセキュリティとプライバシーのリスクおよび可能な軽減策についてのみ論じます。</p>
+<p>一般的に、WoTシステムを保護するために講じられるセキュリティ対策は、システムが直面する可能性のある脅威と攻撃者、および保護する必要がある資産の価値に依存する。さらに、プライバシーのリスクは、<span class="mark">Thing</span>と特定可能な人物との関連性、および直接的な情報とそのような関連性から入手可能な推測される情報の両方に依存する。様々な状況に適応できる脅威モデルを含む、<span class="mark">Web of Things</span>のセキュリティとプライバシーに関する留意点の詳細な議論は、参考情報のドキュメント[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-security-guidelines" title="Web of Things (WoT) Security and Privacy Guidelines">WOT-SECURITY-GUIDELINES</a></cite>]に記載されている。この項では、<span class="mark">WoT Thing Description</span>に直接関連するセキュリティとプライバシーのリスクおよび可能な軽減策についてのみ論じる。</p>
 
-<p>WoTモノの記述は、安全なネットワーク・インターフェースと安全でないネットワーク・インターフェースの両方を記述することができます。モノの記述を既存のネットワーク・インターフェースに後付けする場合、ネットワーク・インターフェースのセキュリティ・ステータスは変わらないと予期されます。</p>
+<p><span class="mark">WoT Thing Description</span>は、安全なネットワークインターフェースと安全でないネットワークインターフェースの両方を記述することができる。<span class="mark">Thing Description</span>を既存のネットワークインターフェースに後付けする場合、ネットワークインターフェースのセキュリティステータスは変わらないと予期される。</p>
 
-<p>WoTモノの記述を用いると、次の項で示しているセキュリティとプライバシーのリスクが生じます。個々のリスクの後で、いくつかの可能な軽減策を提案します。</p>
+<p><span class="mark">WoT Thing Description</span>を用いると、次の項で示しているセキュリティとプライバシーのリスクが生じる。個々のリスクの後で、いくつかの可能な軽減策を提案する。</p>
 
 <section id="sec-security-consideration-context">
 
 <h3 id="x9-1-context-fetching-privacy-risk"><bdi class="secno">9.1</bdi> プライバシーのリスクをフェッチするコンテキスト<a class="self-link" aria-label="§" href="#sec-security-consideration-context"></a></h3>
 
-<p>JSON-LD[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]ドキュメントの<code>@context</code>メンバーで指定されている語彙ファイルをフェッチすると、プライバシーのリスクになりえます。WoTの場合、攻撃者はそのようなフェッチによって生成されるネットワーク・トラフィックを観察することができ、特にドメイン固有の語彙が用いられている場合に、デバイスに関する情報を推測するために、宛先IPアドレスなどのフェッチのメタデータを使用できます。これは、接続が暗号化されていてもリスクであり、DNSプライバシーのリークに関連しています。</p>
+<p>JSON-LD[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]ドキュメントの<code>@context</code>メンバーで指定されている語彙ファイルをフェッチすると、プライバシーのリスクになりえる。WoTの場合、攻撃者はそのようなフェッチによって生成されるネットワークトラフィックを観察することができ、特にドメイン固有の語彙が用いられている場合に、デバイスに関する情報を推測するために、宛先IPアドレスなどのフェッチのメタデータを使用できる。これは、接続が暗号化されていてもリスクであり、DNSプライバシーのリークに関連している。</p>
 
 <dl>
   <dt>軽減策:</dt>
-  <dd>語彙ファイルの実際のフェッチを回避してください。語彙ファイルは可能な限りキャッシュすべきです。<code>@context</code>メンバーのURIが(既知の)語彙の識別子としてのみ機能するようにして、をれを変更不可能にして、解釈デバイスに組み込み、完全にフェッチされなくするのが理想的です。そのためには、既存のURIで変更不可能なデータを参照できるように更新時に新しいURIを用いるべきであるため、厳密なバージョン管理を用いる必要があります。モノの記述のメタデータを解釈するシステムがコンテキスト・ファイルをローカルで利用できる可能性を高めるために、可能な限り有名な標準語彙ファイルを用いてください。</dd>
+  <dd>語彙ファイルの実際のフェッチを回避する。語彙ファイルは可能な限りキャッシュすべきである。<code>@context</code>メンバーのURIが(既知の)語彙の識別子としてのみ機能するようにして、をれを変更不可能にして、解釈デバイスに組み込み、完全にフェッチされなくするのが理想的である。そのためには、既存のURIで変更不可能なデータを参照できるように更新時に新しいURIを用いるべきであるため、厳密なバージョン管理を用いる必要がある。<span class="mark">Thing Description</span>のメタデータを解釈するシステムがコンテキストファイルをローカルで利用できる可能性を高めるために、可能な限り有名な標準語彙ファイルを使用する。</dd>
 </dl>
 
 </section>
@@ -4149,11 +4153,11 @@
 
 <h3 id="x9-2-immutable-identifiers-privacy-risk"><bdi class="secno">9.2</bdi> 不変な識別子に関するプライバシーのリスク<a class="self-link" aria-label="§" href="#sec-security-consideration-id"></a></h3>
 
-<p>識別子(<code>id</code>)を含んでいるモノの記述は、特定可能な人物に関連付けられているモノを記述することができます。このような識別子は、追跡を含む様々なリスクをもたらします。しかし、識別子も変更不可能である場合、デバイスが別の人に販売または譲渡され、その人を追跡するために既知のIDが用いられるため、追跡のリスクが増幅されます。</p>
+<p>識別子(<code>id</code>)を含んでいる<span class="mark">Thing Description</span>は、特定可能な人物に関連付けられている<span class="mark">Thing</span>を記述することができる。このような識別子は、追跡を含む様々なリスクをもたらす。しかし、識別子も変更不可能である場合、デバイスが別の人に販売または譲渡され、その人を追跡するために既知のIDが用いられるため、追跡のリスクが増幅される。</p>
 
 <dl>
   <dt>軽減策:</dt>
-  <dd>すべての識別子は変更可能であるべきであり、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の<code>id</code>を更新するメカニズムがあるべきです。具体的には、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の<code>id</code>はハードウェア内で固定されるべきではありません。しかし、これは、識別子が固定URIであるというリンクト・データの理想と矛盾します。多くの場合、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が再初期化された場合にのみ識別子の更新を認めることは許容されるでしょう。このケースでは、ソフトウェア・エンティティーとしての古い<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は存在しなくなり、新しい<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が作成されます。これは、例えば、デバイスが新しい所有者に販売されたときに追跡の連鎖を断ち切るのに十分でありえます。あるいは、デバイスの運用段階の間により頻繁な変更が必要な場合は、変更時に、承認を与えられたユーザのみに識別子の変更を通知するメカニズムを導入できます。しかし、一部のクラスのデバイス、例えば、医療デバイスでは、一部の法的管轄区域において法律によって変更不可能なIDが求められる場合があります。この場合、そのような変更不可能な識別子を含むモノの記述などのファイルへのアクセスを保護するために特別な注意を払うべきです。このような場合、可能な限り、TDで「真の」変更不可能な識別子を共有しないことが望ましいかもしれません。</dd>
+  <dd>すべての識別子は変更可能であるべきであり、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<code>id</code>を更新するメカニズムがあるべきである。具体的には、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<code>id</code>はハードウェア内で固定されるべきではない。しかし、これは、識別子が固定URIであるというリンクトデータの理想と矛盾する。多くの場合、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が再初期化された場合にのみ識別子の更新を認めることは許容されるだろう。このケースでは、ソフトウェアエンティティーとしての古い<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は存在しなくなり、新しい<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が作成される。これは、例えば、デバイスが新しい所有者に販売されたときに追跡の連鎖を断ち切るのに十分でありえる。あるいは、デバイスの運用段階の間により頻繁な変更が必要な場合は、変更時に、<span class="mark">認可</span>されたユーザのみに識別子の変更を通知するメカニズムを導入できる。しかし、一部のクラスのデバイス、例えば、医療デバイスでは、一部の法的管轄区域において法律によって変更不可能なIDが求められる場合がある。この場合、そのような変更不可能な識別子を含む<span class="mark">Thing Description</span>などのファイルへのアクセスを保護するために特別な注意を払うべきである。このような場合、可能な限り、TDで「真の」変更不可能な識別子を共有しないことが望ましいかもしれない。</dd>
 </dl>
 
 </section>
@@ -4161,13 +4165,13 @@
 
 <h3 id="x9-3-fingerprinting-privacy-risk"><bdi class="secno">9.3</bdi> 指紋に関するプライバシーのリスク<a class="self-link" aria-label="§" href="#sec-security-consideration-fingerprint"></a></h3>
 
-<p>上記のように、TDの<code>id</code>メンバーはプライバシーのリスクを引き起こす可能性があります。しかし、前述のように<code>id</code>を更新して追跡のリスクを軽減しても、TDを特定の物理デバイスに関連付け、そこから指紋採取により特定可能な人物に関連付けることができる場合があります。</p>
+<p>上記のように、TDの<code>id</code>メンバーはプライバシーのリスクを引き起こす可能性がある。しかし、前述のように<code>id</code>を更新して追跡のリスクを軽減しても、TDを特定の物理デバイスに関連付け、そこから指紋採取により特定可能な人物に関連付けることができる場合がある。</p>
 
-<p>指紋採取では特定のデバイスのインスタンスを特定できない場合でも、対話の集合など、TDの情報からデバイスの類型を推測し、この類型を用いて、病状などの特定可能な人物に関する個人情報を推測することができます。</p>
+<p>指紋採取では特定のデバイスのインスタンスを特定できない場合でも、相互作用の集合など、TDの情報からデバイスの類型を推測し、この類型を用いて、病状などの特定可能な人物に関する個人情報を推測することができる。</p>
 
 <dl>
   <dt>軽減策:</dt>
-  <dd><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>に対するモノの記述へのアクセスは、承認されたユーザのみに提供すべきであり、承認のレベルとユースケースに必要な量の情報のみを提供すべきです。例えば、認証が必要なディレクトリ・サービスなどの安全で機密性のあるチャネルを介して、TDが承認されたユーザにのみ配信されていれば、外部の承認されていない当事者がTDにアクセスして指紋を取得することはできません。このリスクをさらに軽減するためには、TDの特定のユースケースに不要な情報は可能な限り除外すべきです。例えば、利用者がモノに関する状態を保存しない場合のデバイスへのアドホックな接続では、<code>id</code>は除外できます。利用者がユースケースで特定の対話を必要としない場合、それは除外できます。利用者が特定の対話の使用を承認されていなければ、同様に除外できます。タイトルや内容記述などの人間が読める情報を表示する機能を利用者が持っていなければ、それらを除外したり、長さがゼロの文字列に置き換えることができます。</dd>
+  <dd><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>に対する<span class="mark">Thing Description</span>へのアクセスは、<span class="mark">認可</span>されたユーザのみに提供すべきであり、<span class="mark">認可</span>のレベルとユースケースに必要な量の情報のみを提供すべきである。例えば、認証が必要なディレクトリサービスなどの安全で機密性のあるチャネルを介して、TDが<span class="mark">認可</span>されたユーザにのみ配信されていれば、外部の<span class="mark">認可</span>されていない当事者がTDにアクセスして指紋を取得することはできない。このリスクをさらに軽減するためには、TDの特定のユースケースに不要な情報は可能な限り除外すべきである。例えば、<span class="mark">Consumer</span>が<span class="mark">Thing</span>に関する状態を保存しない場合のデバイスへのアドホックな接続では、<code>id</code>は除外できる。<span class="mark">Consumer</span>がユースケースで特定の相互作用を必要としない場合、それは除外できる。<span class="mark">Consumer</span>が特定の相互作用の使用を<span class="mark">認可</span>されていなければ、同様に除外できる。タイトルや内容記述などの人間が読める情報を表示する機能を<span class="mark">Consumer</span>が持っていなければ、それらを除外したり、長さがゼロの文字列に置き換えることができる。</dd>
 </dl>
 
 </section>
@@ -4175,11 +4179,11 @@
 
 <h3 id="x9-4-globally-unique-identifier-privacy-risk"><bdi class="secno">9.4</bdi> グローバルに一意な識別子に関するプライバシーのリスク<a class="self-link" aria-label="§" href="#sec-security-consideration-global-id-risk"></a></h3>
 
-<p>グローバルに一意な識別子は、その作成と配信に中央機関が必要な場合、第三者が識別子を知っているため、プライバシーのリスクをもたらします。</p>
+<p>グローバルに一意な識別子は、その作成と配信に中央機関が必要な場合、第三者が識別子を知っているため、プライバシーのリスクをもたらす。</p>
 
 <dl>
   <dt>軽減策:</dt>
-  <dd>TDの<code>id</code>フィールドは、意図的にグローバルに一意であることを求めていません。中央での登録を必要としない分散方式で適切なIDを生成するために利用可能な暗号化のメカニズムがいくつかあります。通常、これらのメカニズムで重複する識別子が生成される可能性は非常に低いためシステム設計ではこれを考慮する必要があります(例えば、必要に応じて重複を検出し、IDを再生成する)。IDの範囲もグローバルである必要はありません。家内や工場内などの特定のコンテキストでのみモノを区別する識別子を用いることもできます。</dd>
+  <dd>TDの<code>id</code>フィールドは、意図的にグローバルに一意であることを求めていない。中央での登録を必要としない分散方式で適切なIDを生成するために利用可能な暗号化のメカニズムがいくつかある。通常、これらのメカニズムで重複する識別子が生成される可能性は非常に低いためシステム設計ではこれを考慮する必要がある(例えば、必要に応じて重複を検出し、IDを再生成する)。IDの範囲もグローバルである必要はない。家内や工場内などの特定のコンテキストでのみ<span class="mark">Thing</span>を区別する識別子を用いることもできる。</dd>
 </dl>
 
 </section>
@@ -4187,11 +4191,11 @@
 
 <h3 id="x9-5-td-interception-and-tampering-security-risk"><bdi class="secno">9.5</bdi> TDの傍受と改ざんに関するセキュリティのリスク<a class="self-link" aria-label="§" href="#sec-security-consideration-TD-tampering"></a></h3>
 
-<p>例えば、TD内のURLを書き換えて、データをキャプチャまたは操作できる悪意のある仲介者にアクセスをリダイレクトすることにより、TDの傍受と改ざんは、中間者攻撃を開始するために使用できます。</p>
+<p>例えば、TD内のURLを書き換えて、データをキャプチャまたは操作できる悪意のある仲介者にアクセスをリダイレクトすることにより、TDの傍受と改ざんは、中間者攻撃を開始するために使用できる。</p>
 
 <dl>
   <dt>軽減策:</dt>
-  <dd>相互に認証されたチャネルを通じてのみモノの記述を取得してください。これにより、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>とサーバーの両方が通信相手の身元を確実に把握できます。これは、承認されたユーザにのみTDを配信するためにも必要です。</dd>
+  <dd>相互に認証されたチャネルを通じてのみ<span class="mark">Thing Description</span>を取得する。これにより、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>とサーバーの両方が通信相手の身元を確実に把握できる。これは、<span class="mark">認可</span>されたユーザにのみTDを配信するためにも必要である。</dd>
 </dl>
 
 </section>
@@ -4199,23 +4203,23 @@
 
 <h3 id="x9-6-context-interception-and-tampering-security-risk"><bdi class="secno">9.6</bdi> コンテキストの傍受と改ざんに関するセキュリティのリスク<a class="self-link" aria-label="§" href="#sec-security-consideration-context-tampering"></a></h3>
 
-<p>コンテキスト・ファイルの傍受および改ざんは、語彙の解釈を変更することにより攻撃を容易にするために使用できます。</p>
+<p>コンテキストファイルの傍受および改ざんは、語彙の解釈を変更することにより攻撃を容易にするために使用できる。</p>
 
 <dl>
   <dt>軽減策:</dt>
-  <dd>コンテキスト・ファイルは認証されたチャネルを介してのみ取得されるのが理想的ですが、逆参照された場合に傍受と変更に対して脆弱であるHTTP URLを用いて多くのコンテキストが示されることは注意に値します(そして残念です)。しかし、コンテキスト・ファイルが変更不可能かつキャッシュされ、可能な限り逆参照が回避されれば、このリスクは低減できます。</dd>
+  <dd>コンテキストファイルは認証されたチャネルを介してのみ取得されるのが理想的であるが、逆参照された場合に傍受と変更に対して脆弱であるHTTP URLを用いて多くのコンテキストが示されることは注意に値する(そして残念である)。しかし、コンテキストファイルが変更不可能かつキャッシュされ、可能な限り逆参照が回避されれば、このリスクは低減できる。</dd>
 </dl>
 
 </section>
 <section id="sec-security-consideration-inferencing">
 
-<h3 id="x9-7-inferencing-of-personally-identifiable-information-privacy-risk"><bdi class="secno">9.7</bdi> 個人を特定できる情報の推測に関するプライバシーのリスク<a class="self-link" aria-label="§" href="#sec-security-consideration-inferencing"></a></h3>
+<h3 id="x9-7-inferencing-of-personally-identifiable-information-privacy-risk"><bdi class="secno">9.7</bdi> <span class="mark">個人識別可能情報</span>の推測に関するプライバシーのリスク<a class="self-link" aria-label="§" href="#sec-security-consideration-inferencing"></a></h3>
 
-<p>多くの場所では、ユーザのプライバシーを保護するために、個人を特定できる情報、つまり特定の人物に関連付けることができる情報の取り扱いに法的要件があります。もちろん、そのような情報はIoTデバイスによって直接生成される可能性があります。しかし、IoTデバイスの存在とメタデータ(モノの記述に保存される種類のデータ)は、個人を特定できる情報を含めたり、推測するために利用されたりする可能性もあります。この情報は、特定の人が特定の種類のデバイスを所有しているという事実と同じくらい単純である場合がありますが、それがその人物に関する追加の推論につながる可能性があります。</p>
+<p>多くの場所では、ユーザのプライバシーを保護するために、<span class="mark">個人識別可能情報</span>、つまり特定の人物に関連付けることができる情報の取り扱いに法的要件がある。もちろん、そのような情報はIoTデバイスによって直接生成される可能性がある。しかし、IoTデバイスの存在とメタデータ(<span class="mark">Thing Description</span>に保存される種類のデータ)は、<span class="mark">個人識別可能情報</span>を含めたり、推測するために利用されたりする可能性もある。この情報は、特定の人が特定の種類のデバイスを所有しているという事実と同じくらい単純である場合があるが、それがその人物に関する追加の推論につながる可能性がある。</p>
 
 <dl>
   <dt>軽減策:</dt>
-  <dd>個人のデバイスに関連付けられたモノの記述を、個人を特定できる情報が含まれているかのように扱ってください。この原則の適用事例として、ユーザの同意を得る方法を検討してください。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>が生成する個人を特定できるデータの使用に対する同意は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>とデータを利用するシステムとを組み合わせる際にしばしば得られます。これは、デバイスにアクセスするために、モノの記述がローカル・ディレクトリやモノの記述を利用するシステムに登録される際にも多いです。このケースでは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のデータの利用に対する同意は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のモノの記述へのアクセスに関する同意と組み合わせることができます。2番目の例として、TDに個人を特定できる情報を含むことを検討する場合には、TDを無期限に保持したり、同意を得られた以外の目的で使用したりすべきではありません。</dd>
+  <dd>個人のデバイスに関連付けられた<span class="mark">Thing Description</span>を、<span class="mark">個人識別可能情報</span>が含まれているかのように扱う。この原則の適用事例として、ユーザの同意を得る方法を検討する。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>が生成する個人を特定できるデータの使用に対する同意は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>とデータを利用するシステムとを組み合わせる際にしばしば得られる。これは、デバイスにアクセスするために、<span class="mark">Thing Description</span>がローカルディレクトリや<span class="mark">Thing Description</span>を利用するシステムに登録される際にも多い。このケースでは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のデータの利用に対する同意は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<span class="mark">Thing Description</span>へのアクセスに関する同意と組み合わせることができる。2番目の例として、TDに<span class="mark">個人識別可能情報</span>を含むことを検討する場合には、TDを無期限に保持したり、同意を得られた以外の目的で使用したりすべきではない。</dd>
 </dl>
 
 </section>
@@ -4224,9 +4228,9 @@
 
 <h2 id="x10-iana-considerations"><bdi class="secno">10.</bdi> IANAに関する留意点<a class="self-link" aria-label="§" href="#iana-section"></a></h2>
 
-    <section id="media-type-section">
+<section id="media-type-section">
 
-<h3 id="x10-1-application-td-json-media-type-registration"><bdi class="secno">10.1</bdi> <code>application/td+json</code>メディア・タイプの登録<a class="self-link" aria-label="§" href="#media-type-section"></a></h3>
+<h3 id="x10-1-application-td-json-media-type-registration"><bdi class="secno">10.1</bdi> <code>application/td+json</code>メディアタイプの登録<a class="self-link" aria-label="§" href="#media-type-section"></a></h3>
 
 <dl>
   <dt>タイプ名:</dt>
@@ -4241,40 +4245,40 @@
   <dd><a href="https://tools.ietf.org/html/rfc6839#section-3.1">RFC&nbsp;6839の3.1項</a>を参照。</dd>
   <dt>セキュリティに関する留意点:</dt>
   <dd><a href="https://tools.ietf.org/html/rfc8259#section-12">RFC&nbsp;8259の12項</a>を参照。
-<p><span class="rfc2119-assertion" id="iana-security-execution">WoTモノの記述は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のメタデータの純粋なデータ交換形式であることを目指しているため、そのシリアル化は、解析されるJavaScriptの<code>eval()</code>関数などのコード実行メカニズムを介して渡されるべきではありません(<em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em>)。</span>(不正な)ドキュメントには、実行時にシステムのセキュリティを危険にさらす予期しない副作用を引き起こす可能性のあるコードが含まれている場合があります。</p>
-<p>WoTモノの記述はJSON-LD 1.1プロセッサで評価できます。これは通常、遠隔のコンテキスト(つまり、TDコンテキスト拡張。<a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions"><abbr title="World Wide Web Consortium">W3C</abbr> WoTモノの記述の7項</a>を参照)へのリンクを自動的にたどり、その結果、個々に対する<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>の明示的なリクエストがなくてもファイルが転送されます。第三者が遠隔のコンテキストを提供している場合、それによって彼らがプライバシー上の懸念につながる使用パターンや同様の情報を収集できる場合があります。<span class="rfc2119-assertion" id="iana-security-remote">資源に制約のあるデバイスでの実装では、(JSON-LD処理とは対照的に)未加工のJSONの処理を実行すると思われますが、一般的に実装は、サポートしているコンテキスト拡張の検査済みのバージョンを静的にキャッシュし、遠隔のコンテキストへのリンクをたどらないようにすべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span>代わりに、サポートしているコンテキスト拡張は、安全なソフトウェア更新メカニズムにより管理できます。</p>
-<p>HTTPなどの安全でない接続を通じてウェブから読み込まれたコンテキスト拡張(<a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions"><abbr title="World Wide Web Consortium">W3C</abbr> WoTモノの記述の7項</a>を参照)には、セキュリティを侵害しえる方法で<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>を変更するといった、攻撃者による変更が行われるリスクがあります。<span class="rfc2119-assertion" id="iana-security-alter">このため、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>は、システムによる利用を許可する前に、遠隔のコンテキストを再検査してキャッシュすべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
-<p>JSON-LD処理には通常、長いIRI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3987" title="Internationalized Resource Identifiers (IRIs)">RFC3987</a></cite>]の短い用語への置換えが含まれることを考慮すると、JSON-LD 1.1プロセッサを用いて処理するとWoTモノの記述が大幅に拡張され、最悪の場合、結果のデータによって受信者の資源がすべて消費される可能性があります。<span class="rfc2119-assertion" id="iana-security-expansion"><a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>は、TDメタデータを懐疑的に扱うべきです(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
+<p><span class="rfc2119-assertion" id="iana-security-execution"><span class="mark">WoT Thing Description</span>は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のメタデータの純粋なデータ交換形式であることを目指しているため、その<span class="mark">シリアライゼーション</span>は、解析されるJavaScriptの<code>eval()</code>関数などのコード実行メカニズムを介して渡されるべきではない(<em class="rfc2119" title="SHOULD NOT">SHOULD NOT</em>)。</span>(不正な)ドキュメントには、実行時にシステムのセキュリティを危険にさらす予期しない副作用を引き起こす可能性のあるコードが含まれている場合がある。</p>
+<p><span class="mark">WoT Thing Description</span>はJSON-LD 1.1プロセッサで評価できる。これは通常、遠隔のコンテキスト(つまり、TDコンテキスト拡張。<a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions"><abbr title="World Wide Web Consortium">W3C</abbr> <span class="mark">WoT Thing Description</span>の7項</a>を参照)へのリンクを自動的にたどり、その結果、個々に対する<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>の明示的なリクエストがなくてもファイルが転送される。第三者が遠隔のコンテキストを提供している場合、それによって彼らがプライバシー上の懸念につながる使用パターンや同様の情報を収集できる場合がある。<span class="rfc2119-assertion" id="iana-security-remote">資源に制約のあるデバイスでの実装では、(JSON-LD処理とは対照的に)未加工のJSONの処理を実行すると思われるが、一般的に実装は、サポートしているコンテキスト拡張の検査済みのバージョンを静的にキャッシュし、遠隔のコンテキストへのリンクをたどらないようにすべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span>代わりに、サポートしているコンテキスト拡張は、安全なソフトウェア更新メカニズムにより管理できる。</p>
+<p>HTTPなどの安全でない接続を通じてウェブから読み込まれたコンテキスト拡張(<a href="https://www.w3.org/TR/wot-thing-description/#sec-context-extensions"><abbr title="World Wide Web Consortium">W3C</abbr> <span class="mark">WoT Thing Description</span>の7項</a>を参照)には、セキュリティを侵害しえる方法で<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>を変更するといった、攻撃者による変更が行われるリスクがある。<span class="rfc2119-assertion" id="iana-security-alter">このため、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>は、システムによる利用を許可する前に、遠隔のコンテキストを再検査してキャッシュすべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
+<p>JSON-LD処理には通常、長いIRI[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3987" title="Internationalized Resource Identifiers (IRIs)">RFC3987</a></cite>]の短い用語への置換えが含まれることを考慮すると、JSON-LD 1.1プロセッサを用いて処理すると<span class="mark">WoT Thing Description</span>が大幅に拡張され、最悪の場合、結果のデータによって受信者の資源がすべて消費される可能性がある。<span class="rfc2119-assertion" id="iana-security-expansion"><a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>は、TDメタデータを懐疑的に扱うべきである(<em class="rfc2119" title="SHOULD">SHOULD</em>)。</span></p>
   </dd>
   <dt>互換性に関する留意点:</dt>
   <dd><a href="https://tools.ietf.org/html/rfc8259">RFC&nbsp;8259</a>を参照。
-<p>適合と不適合の両方のコンテンツを処理するための規則は、この仕様で定義しています。</p>
+<p>適合と不適合の両方のコンテンツを処理するための規則は、この仕様で定義している。</p>
   </dd>
   <dt>公開済み仕様書:</dt>
   <dd><a href="https://w3c.github.io/wot-thing-description">https://w3c.github.io/wot-thing-description</a></dd>
-  <dt>このメディア・タイプを使用するアプリケーション:</dt>
-  <dd><abbr title="World Wide Web Consortium">W3C</abbr>モノのウェブに関与しているすべてのエンティティー、つまり、<a href="https://www.w3.org/TR/wot-architecture">モノのウェブ(WoT)アーキテクチャ</a>で定義されている<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>、および仲介。</dd>
+  <dt>このメディアタイプを使用するアプリケーション:</dt>
+  <dd><abbr title="World Wide Web Consortium">W3C</abbr> <span class="mark">Web of Things</span>に関与しているすべてのエンティティー、つまり、<a href="https://www.w3.org/TR/wot-architecture"><span class="mark">Web of Things</span> (WoT) アーキテクチャ</a>で定義されている<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>、および<span class="mark">Intermediary</span>。</dd>
   <dt>フラグメント識別子に関する留意点:</dt>
   <dd><a href="https://tools.ietf.org/html/rfc6839#section-3.1">RFC&nbsp;6839の3.1項</a>を参照。</dd>
   <dt>追加情報:</dt>
   <dd>
   <dl>
-    <dt>マジック・ナンバー:</dt>
+    <dt>マジックナンバー:</dt>
     <dd>該当しない</dd>
     <dt>ファイル拡張子:</dt>
     <dd>.jsontd</dd>
-    <dt>マッキントッシュ・ファイル・タイプ・コード:</dt>
+    <dt>マッキントッシュファイルタイプコード:</dt>
     <dd>TEXT</dd>
   </dl>
   </dd>
   <dt>詳細情報に関する連絡先:</dt>
   <dd>Matthias Kovatsch &lt;w3c@kovatsch.net&gt;</dd>
   <dt>意図する使途:</dt>
-  <dd>COMMON</dd>
+  <dd>汎用</dd>
   <dt>使用上の制限:</dt>
   <dd>なし</dd>
   <dt>著者:</dt>
-  <dd>WoTモノの記述の仕様は、Web of Thingsワーキンググループの成果です。</dd>
+  <dd><span class="mark">WoT Thing Description</span>の仕様は、Web of Thingsワーキンググループの成果である。</dd>
   <dt>改版管理者:</dt>
   <dd><abbr title="World Wide Web Consortium">W3C</abbr></dd>
 </dl>
@@ -4284,44 +4288,44 @@
 
 <h3 id="x10-2-coap-content-format-registration"><bdi class="secno">10.2</bdi> CoAPコンテンツ形式の登録<a class="self-link" aria-label="§" href="#content-format-section"></a></h3>
 
-<p>IANAは、<a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml">Constrained RESTful Environments(CoRE)パラメータ</a>のレジストリ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>]内の<a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats">CoAPコンテンツ形式</a>サブレジストリのメディア・タイプにコンパクトなCoAPコンテンツ形式IDを割り当てています。WoTモノの記述のコンテンツ形式IDは、432です。</p>
+<p>IANAは、<a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml">Constrained RESTful Environments(CoRE)パラメータ</a>のレジストリ[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>]内の<a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats">CoAPコンテンツ形式</a>サブレジストリのメディアタイプにコンパクトなCoAPコンテンツ形式IDを割り当てている。<span class="mark">WoT Thing Description</span>のコンテンツ形式IDは、432である。</p>
 
 <dl>
-  <dt>メディア・タイプ:</dt>
+  <dt>メディアタイプ:</dt>
   <dd>application/td+json</dd>
   <dt>コード化:</dt>
   <dd>-</dd>
   <dt>ID:</dt>
   <dd>432</dd>
   <dt>参考文献:</dt>
-  <dd>[<a href="https://w3c.github.io/wot-thing-description">"モノのウェブ(WoT)モノの記述", 2019年5月</a>]</dd>
+  <dd>[<a href="https://w3c.github.io/wot-thing-description">"<span class="mark">Web of Things (WoT) Thing Description</span>", 2019年5月</a>]</dd>
 </dl>
 
 </section>
 </section>
 <section id="example-serialization" class="appendix informative">
 
-<h2 id="a-example-thing-description-instances"><bdi class="secno">A.</bdi> モノの記述のインスタンスの例<a class="self-link" aria-label="§" href="#example-serialization"></a></h2>
+<h2 id="a-example-thing-description-instances"><bdi class="secno">A.</bdi> <span class="mark">Thing Description</span>のインスタンスの例<a class="self-link" aria-label="§" href="#example-serialization"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
     <section id="myLampThing-example-serialization">
 
-<h3 id="a-1-mylampthing-example-with-coap-protocol-binding"><bdi class="secno">A.1</bdi> CoAPプロトコル・バインディングを用いたMyLampThingの例<a class="self-link" aria-label="§" href="#myLampThing-example-serialization"></a></h3>
+<h3 id="a-1-mylampthing-example-with-coap-protocol-binding"><bdi class="secno">A.1</bdi> CoAPプロトコルバインディングを用いたMyLampThingの例<a class="self-link" aria-label="§" href="#myLampThing-example-serialization"></a></h3>
 
-<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の機能リスト</p>
+<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の機能リスト</p>
 
 <ul>
   <li>タイトル: MyLampThing</li>
   <li>コンテキスト拡張: なし</li>
-  <li>提供されるアフォーダンス: 1プロパティー、1アクション、1イベント</li>
+  <li>提供されるアフォーダンス: 1 <span class="mark">Property</span>、1 <span class="mark">Action</span>、1 <span class="mark">Event</span></li>
   <li>セキュリティ: PSKSecurityScheme</li>
-  <li>プロトコル・バインディング: CoAP [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>] over TLS</li>
-  <li>コメント: <a href="#adding-protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">7.2</bdi> プロトコル・バインディングの追加</a>も参照。</li>
+  <li>プロトコルバインディング: CoAP [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7252" title="The Constrained Application Protocol (CoAP)">RFC7252</a></cite>] over TLS</li>
+  <li>コメント: <a href="#adding-protocol-bindings" class="sec-ref">§&nbsp;<bdi class="secno">7.2</bdi> プロトコルバインディングの追加</a>も参照。</li>
 </ul>
 
 <div class="example" id="example-33-mylampthing-with-coap-protocol-binding">
-<div class="marker"><a class="self-link" href="#example-33-mylampthing-with-coap-protocol-binding">例<bdi>33</bdi></a><span class="example-title">: CoAPプロトコル・バインディングを用いたMyLampThing</span></div>
+<div class="marker"><a class="self-link" href="#example-33-mylampthing-with-coap-protocol-binding">例<bdi>33</bdi></a><span class="example-title">: CoAPプロトコルバインディングを用いたMyLampThing</span></div>
 <pre aria-busy="false"><code class="hljs json">{
    <span class="hljs-attr">"@context"</span>: [
       <span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>,
@@ -4370,21 +4374,21 @@
 </section>
 <section id="myLightSensor-example-serialization">
 
-<h3 id="a-2-myilluminancesensor-example-with-mqtt-protocol-binding"><bdi class="secno">A.2</bdi> MQTTプロトコル・バインディングを用いたMyIlluminanceSensorの例<a class="self-link" aria-label="§" href="#myLightSensor-example-serialization"></a></h3>
+<h3 id="a-2-myilluminancesensor-example-with-mqtt-protocol-binding"><bdi class="secno">A.2</bdi> MQTTプロトコルバインディングを用いたMyIlluminanceSensorの例<a class="self-link" aria-label="§" href="#myLightSensor-example-serialization"></a></h3>
 
-<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の機能リスト:</p>
+<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の機能リスト:</p>
 
 <ul>
   <li>タイトル: MyIlluminanceSensor</li>
   <li>コンテキスト拡張: なし</li>
-  <li>提供されるアフォーダンス: 1イベント</li>
+  <li>提供されるアフォーダンス: 1 <span class="mark">Event</span></li>
   <li>セキュリティ: なし</li>
-  <li>プロトコル・バインディング: MQTT [<cite><a class="bibref" data-link-type="biblio" href="#bib-mqtt" title="MQTT Version 3.1.1">MQTT</a></cite>]</li>
-  <li>コメント: MQTTクライアントは、アドレス192.168.1.187:1883の背後で実行されているMQTTブローカーにより、照度データ(数値はテキスト形式でシリアル化されている)を<code>/illuminance</code>というトピックに頻繁に公開します。</li>
+  <li>プロトコルバインディング: MQTT [<cite><a class="bibref" data-link-type="biblio" href="#bib-mqtt" title="MQTT Version 3.1.1">MQTT</a></cite>]</li>
+  <li>コメント: MQTTクライアントは、アドレス192.168.1.187:1883の背後で実行されているMQTTブローカーにより、照度データ(数値はテキスト形式で<span class="mark">シリアライズ</span>されている)を<code>/illuminance</code>というトピックに頻繁に公開する。</li>
 </ul>
 
 <div class="example" id="example-34-myilluminancesensor-with-mqtt-protocol-binding">
-<div class="marker"><a class="self-link" href="#example-34-myilluminancesensor-with-mqtt-protocol-binding">例<bdi>34</bdi></a><span class="example-title">: MQTTプロトコル・バインディングを用いたMyIlluminanceSensor</span></div>
+<div class="marker"><a class="self-link" href="#example-34-myilluminancesensor-with-mqtt-protocol-binding">例<bdi>34</bdi></a><span class="example-title">: MQTTプロトコルバインディングを用いたMyIlluminanceSensor</span></div>
 <pre aria-busy="false"><code class="hljs json">{   
     <span class="hljs-attr">"@context"</span>: <span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>,
     <span class="hljs-attr">"title"</span>: <span class="hljs-string">"MyIlluminanceSensor"</span>,
@@ -4408,21 +4412,21 @@
 </section>
 <section id="webhook-example-serialization">
 
-<h3 id="a-3-webhook-event-example"><bdi class="secno">A.3</bdi> Webhookイベントの例<a class="self-link" aria-label="§" href="#webhook-example-serialization"></a></h3>
+<h3 id="a-3-webhook-event-example"><bdi class="secno">A.3</bdi> Webhook <span class="mark">Event</span>の例<a class="self-link" aria-label="§" href="#webhook-example-serialization"></a></h3>
 
-<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の機能リスト:</p>
+<p><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の機能リスト:</p>
 
 <ul>
   <li>タイトル: WebhookThing</li>
-  <li>コンテキスト拡張: HTTP<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>の補足を使用(htv接頭辞は既にTDコンテキストに含まれている)</li>
-  <li>提供されるアフォーダンス: 1イベント</li>
+  <li>コンテキスト拡張: HTTP<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>の補足を使用(htv接頭辞は既にTDコンテキストに含まれている)</li>
+  <li>提供されるアフォーダンス: 1 <span class="mark">Event</span></li>
   <li>セキュリティ: なし</li>
-  <li>プロトコル・バインディング: HTTP</li>
-  <li>コメント: <i>WebhookThing</i>は、Webhookメカニズムを用いて<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>に定期的に最新の温度値をプッシュするイベント・アフォーダンス<code>temperature</code>を提供し、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>が提供するコールバックURIにPOSTリクエストを送信します。これを記述するために、<code>subscription</code>メンバーは、書き込み専用パラメータ<code>callbackURL</code>を定義し、<code>subscribeevent</code>フォームを介して送信しなければなりません。読み取り専用パラメータ<code>subscriptionID</code>が購読によって返されます。<i>WebhookThing</i>は、<code>data</code>によって定義されたペイロードを用いて、このコールバックURIに定期的にPOSTを行います。購読を解除するには、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>はURIテンプレートを用いる<code>unsubscribeevent</code>フォームを送信する必要があります。<code>uriVariables</code>メンバーは、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>に<code>subscriptionID</code>文字列を含めるように通知します。これは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いて適切なセマンティック・アノテーションを含めることにより、さらに自動化できます。または、<code>subscription</code>と同様に<code>cancellation</code>メンバーを用いて購読を解除することを想像し、これを、購読を解除するペイロードを持つPOSTリクエストを記述する<code>unsubscribeevent</code>フォームと組み合わせることができます。</li>
+  <li>プロトコルバインディング: HTTP</li>
+  <li>コメント: <i>WebhookThing</i>は、Webhookメカニズムを用いて<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に定期的に最新の温度値をプッシュする<span class="mark">Event</span>アフォーダンス<code>temperature</code>を提供し、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>が提供するコールバックURIにPOSTリクエストを送信する。これを記述するために、<code>subscription</code>メンバーは、書き込み専用パラメータ<code>callbackURL</code>を定義し、<code>subscribeevent</code>フォームを介して送信しなければならない。読み取り専用パラメータ<code>subscriptionID</code>が<span class="mark">登録</span>によって返される。<i>WebhookThing</i>は、<code>data</code>によって定義されたペイロードを用いて、このコールバックURIに定期的にPOSTを行う。<span class="mark">登録解除</span>をするには、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>はURIテンプレートを用いる<code>unsubscribeevent</code>フォームを送信する必要がある。<code>uriVariables</code>メンバーは、<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に<code>subscriptionID</code>文字列を含めるように通知する。これは、<a href="#dfn-context-ext" class="internalDFN" data-link-type="dfn">TDコンテキスト拡張</a>を用いて適切なセマンティックアノテーションを含めることにより、さらに自動化できる。または、<code>subscription</code>と同様に<code>cancellation</code>メンバーを用いて<span class="mark">登録解除</span>をすることを想像し、これを、<span class="mark">登録解除</span>をするペイロードを持つPOSTリクエストを記述する<code>unsubscribeevent</code>フォームと組み合わせることができる。</li>
 </ul>
 
 <div class="example" id="example-35-temperature-event-with-subscription-and-cancellation">
-<div class="marker"><a class="self-link" href="#example-35-temperature-event-with-subscription-and-cancellation">例<bdi>35</bdi></a><span class="example-title">: 購読と中止を伴う温度イベント</span></div>
+<div class="marker"><a class="self-link" href="#example-35-temperature-event-with-subscription-and-cancellation">例<bdi>35</bdi></a><span class="example-title">: <span class="mark">登録</span>と中止を伴う温度<span class="mark">Event</span></span></div>
 <pre aria-busy="false"><code class="hljs json">{
     <span class="hljs-attr">"@context"</span>: <span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>,
     <span class="hljs-attr">"id"</span>: <span class="hljs-string">"urn:dev:ops:32473-Thing-1234"</span>,
@@ -4489,21 +4493,21 @@
 
 <h2 id="b-json-schema-for-td-instance-validation"><bdi class="secno">B.</bdi> TDのインスタンス検証用JSONスキーマ<a class="self-link" aria-label="§" href="#json-schema-for-validation"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
-<p>下記は、JSONベースの形式でシリアル化されたモノの記述のインスタンスを構文的に検証するためのJSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]ドキュメントです。</p>
+<p>下記は、JSONベースの形式で<span class="mark">シリアライズ</span>された<span class="mark">Thing Description</span>のインスタンスを構文的に検証するためのJSONスキーマ[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-schema" title="JSON Schema Validation: A Vocabulary for Structural Validation of JSON">JSON-SCHEMA</a></cite>]ドキュメントである。</p>
 
 <div class="note" role="note" id="issue-container-generatedID-1">
 <div role="heading" class="note-title marker" id="h-note-1" aria-level="3"><span>注</span></div>
-<p class="">このドキュメントで定義しているモノの記述では、JSON-LD[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]で知られている<code>@context</code>メカニズムを用いて外部語彙を追加でき、これらの外部語彙の用語は、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で定義している用語に加えて使用できます。そのため、下記のJSONスキーマはその点で意図的に厳密ではありません。外部語彙が用いられていない場合には、より厳密な検証を行うために、異なる範囲/レベルで<code>additionalProperties</code>スキーマ・プロパティーの値である<code>true</code>を<code>false</code>に置き換えることができます。</p>
+<p class="">このドキュメントで定義している<span class="mark">Thing Description</span>では、JSON-LD[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">json-ld11</a></cite>]で知られている<code>@context</code>メカニズムを用いて外部語彙を追加でき、これらの外部語彙の用語は、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で定義している用語に加えて使用できる。そのため、下記のJSONスキーマはその点で意図的に厳密ではない。外部語彙が用いられていない場合には、より厳密な検証を行うために、異なる範囲/レベルで<code>additionalProperties</code>スキーマプロパティーの値である<code>true</code>を<code>false</code>に置き換えることができる。</p>
 </div>
 
 <div class="note" role="note" id="issue-container-generatedID-2">
 <div role="heading" class="note-title marker" id="h-note-2" aria-level="3"><span>注</span></div>
-<p class="">一部のJSONスキーマ検証ツールは、<code>iri</code>の文字列形式をサポートしていないことに注意してください。</p>
+<p class="">一部のJSONスキーマ検証ツールは、<code>iri</code>の文字列形式をサポートしていないことに注意していただきたい。</p>
 </div>
 
-<p>TDのインスタンスを検証するための次のJSONスキーマでは、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を持つ用語が存在している必要はありません。したがって、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を持つ用語はオプションです。(<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>も参照)</p>
+<p>TDのインスタンスを検証するための次のJSONスキーマでは、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を持つ用語が存在している必要はない。したがって、<a href="#dfn-default-value" class="internalDFN" data-link-type="dfn">デフォルト値</a>を持つ用語はオプションである。(<a href="#sec-default-values" class="sec-ref">§&nbsp;<bdi class="secno">5.4</bdi> デフォルト値の定義</a>も参照)</p>
 
 <pre class="advisement" aria-busy="false"><code class="hljs">    {
     "title": "WoT TD Schema - 16 October 2019",
@@ -5543,45 +5547,45 @@
 </section>
 <section id="thing-templates" class="appendix informative">
 
-<h2 id="c-thing-description-templates"><bdi class="secno">C.</bdi> モノの記述テンプレート<a class="self-link" aria-label="§" href="#thing-templates"></a></h2>
+<h2 id="c-thing-description-templates"><bdi class="secno">C.</bdi> <span class="mark">Thing Description</span>テンプレート<a class="self-link" aria-label="§" href="#thing-templates"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
-<p><em>モノの記述テンプレート</em>は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の<em>クラス</em>の記述です。これは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のグループ全体で共有されるプロパティー、アクション、イベント、および共通のメタデータを記述し、それにより、クラウド・サーバーが、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>ごとに行うのは現実的ではない、何千ものデバイスの共通処理を行うことができます。モノの記述テンプレートは、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>と同じコア語彙と情報モデルを用います。</p>
+<p><em><span class="mark">Thing Description</span>テンプレート</em>は、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の<em>クラス</em>の記述である。これは、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のグループ全体で共有されるプロパティー、アクション、イベント、および共通のメタデータを記述し、それにより、クラウドサーバーが、<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>ごとに行うのは現実的ではない、何千ものデバイスの共通処理を行うことができる。<span class="mark">Thing Description</span>テンプレートは、<a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>と同じコア語彙と情報モデルを用いる。</p>
 
-<p>モノの記述テンプレートにより、次のことが可能になります。</p>
+<p><span class="mark">Thing Description</span>テンプレートにより、次のことが可能になる。</p>
 
 <ul>
-  <li>クラウド・サービスによる複数の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の管理。</li>
-  <li>未開発のデバイス/<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>のシミュレーション。</li>
-  <li><a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の共通するモデルを共有する様々なメーカーのデバイスにまたがる共通のアプリケーション。</li>
-      <li>複数のモデルを1つの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>に結合すること。</li>
+  <li>クラウドサービスによる複数の<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の管理。</li>
+  <li>未開発のデバイス/<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>のシミュレーション。</li>
+  <li><a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の共通するモデルを共有する様々なメーカーのデバイスにまたがる共通のアプリケーション。</li>
+      <li>複数のモデルを1つの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>に結合すること。</li>
 </ul>
 
-<p>モノの記述テンプレートは、インターフェースとデバイスとの可能な対話(プロパティー、アクション、イベント)の論理的な記述ですが、シリアル番号、GPS上の位置、セキュリティ情報、具体的なプロトコル・エンドポイントなどのデバイス固有の情報は含まれていません。</p>
+<p><span class="mark">Thing Description</span>テンプレートは、インターフェースとデバイスとの可能な相互作用(プロパティー、アクション、イベント)の論理的な記述であるが、シリアル番号、GPS上の位置、セキュリティ情報、具体的なプロトコルエンドポイントなどのデバイス固有の情報は含まれていない。</p>
 
-<p>モノの記述テンプレートは、特定のエンドポイントに対する<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコル・バインディング</a>を含まず、特定のセキュリティ・メカニズムを定義しないため、<em>フォーム</em>と<em>securityDefinitions</em>(セキュリティ定義)および<em>セキュリティ</em>のキーが存在してはなりません。</p>
+<p><span class="mark">Thing Description</span>テンプレートは、特定のエンドポイントに対する<a href="#dfn-protocol-binding" class="internalDFN" data-link-type="dfn">プロトコルバインディング</a>を含まず、特定のセキュリティメカニズムを定義しないため、<em>フォーム</em>と<em>securityDefinitions</em>(セキュリティ定義)および<em>セキュリティ</em>のキーが存在してはならない。</p>
 
-<p>同じモノの記述テンプレートを複数のベンダーの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>に実装できます。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>は複数のモノの記述テンプレートを実装し、追加のメタデータ(ベンダー、場所、セキュリティ)を定義し、具体的なプロトコルへのバインディングを定義できます。共通する<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>に結合される様々なモノの記述テンプレートのプロパティー、アクション、およびイベント間の衝突を避けるために、これらすべての識別子は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の中で一意でなければなりません。</p>
+<p>同じ<span class="mark">Thing Description</span>テンプレートを複数のベンダーの<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>に実装できる。<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>は複数の<span class="mark">Thing Description</span>テンプレートを実装し、追加のメタデータ(ベンダー、場所、セキュリティ)を定義し、具体的なプロトコルへのバインディングを定義できる。共通する<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>に結合される様々な<span class="mark">Thing Description</span>テンプレートのプロパティー、アクション、およびイベント間の衝突を避けるために、これらすべての識別子は<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の中で一意でなければならない。</p>
 
-<p>あるクラスのデバイスに共通するモノの記述テンプレートを用いると、ベンダーにまたがるアプリケーションを記述でき、アプリケーション開発者にとってより魅力的な市場が作られます。具体的なモノの記述は、複数のモノの記述テンプレートを実装できるため、機能ブロックを1つの結合デバイスに統合することができます。</p>
+<p>あるクラスのデバイスに共通する<span class="mark">Thing Description</span>テンプレートを用いると、ベンダーにまたがるアプリケーションを記述でき、アプリケーション開発者にとってより魅力的な市場が作られる。具体的な<span class="mark">Thing Description</span>は、複数の<span class="mark">Thing Description</span>テンプレートを実装できるため、機能ブロックを1つの結合デバイスに統合することができる。</p>
 
-<p>クラウド・ベンダーのビジネス・モデルは通常、何千もの同じデバイスの管理に基づいて構築されています。同じモノの記述テンプレートを持つすべてのデバイスは、クラウド・アプリケーションが同じ方法で管理できます。インターフェースとインスタンスを別々に扱うと、多数のシミュレートされたデバイスを簡単に作成できます。</p>
+<p>クラウドベンダーのビジネスモデルは通常、何千もの同じデバイスの管理に基づいて構築されている。同じ<span class="mark">Thing Description</span>テンプレートを持つすべてのデバイスは、クラウドアプリケーションが同じ方法で管理できる。インターフェースとインスタンスを別々に扱うと、多数のシミュレートされたデバイスを簡単に作成できる。</p>
 
-<p>モノの記述テンプレートは、一部のオプションと必須の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>が存在しないモノの記述のサブセットであるため、モノの記述と同じ方法、同じ形式でシリアル化できます。モノのテンプレートのインスタンスは、必須の用語が欠けているため、モノの記述インスタンスと同じ方法で検証することはできないことに注意してください。</p>
+<p><span class="mark">Thing Description</span>テンプレートは、一部のオプションと必須の<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>が存在しない<span class="mark">Thing Description</span>のサブセットであるため、<span class="mark">Thing Description</span>と同じ方法、同じ形式で<span class="mark">シリアライズ</span>できる。<span class="mark">Thing</span>のテンプレートのインスタンスは、必須の用語が欠けているため、<span class="mark">Thing Description</span>インスタンスと同じ方法で検証することはできないことに注意していただきたい。</p>
 
 <section id="thing-template-examples">
 
-<h3 id="c-1-thing-description-template-examples"><bdi class="secno">C.1</bdi> モノの記述テンプレートの例<a class="self-link" aria-label="§" href="#thing-template-examples"></a></h3>
+<h3 id="c-1-thing-description-template-examples"><bdi class="secno">C.1</bdi> <span class="mark">Thing Description</span>テンプレートの例<a class="self-link" aria-label="§" href="#thing-template-examples"></a></h3>
 
-この項では、照明のモノの記述テンプレートとブザーのモノの記述テンプレートを示します。
+この項では、照明の<span class="mark">Thing Description</span>テンプレートとブザーの<span class="mark">Thing Description</span>テンプレートを示す。
 
 <section id="lamp-thing-template">
 
-<h4 id="c-1-1-thing-description-template-lamp"><bdi class="secno">C.1.1</bdi> モノの記述テンプレート: 照明<a class="self-link" aria-label="§" href="#lamp-thing-template"></a></h4>
+<h4 id="c-1-1-thing-description-template-lamp"><bdi class="secno">C.1.1</bdi> <span class="mark">Thing Description</span>テンプレート: 照明<a class="self-link" aria-label="§" href="#lamp-thing-template"></a></h4>
 
 <div class="example" id="example-36-mylampthingtemplate-serialized-in-json">
-<div class="marker"><a class="self-link" href="#example-36-mylampthingtemplate-serialized-in-json">例<bdi>36</bdi></a><span class="example-title">: JSONでシリアル化されたMyLampThingTemplate</span>
+<div class="marker"><a class="self-link" href="#example-36-mylampthingtemplate-serialized-in-json">例<bdi>36</bdi></a><span class="example-title">: JSONで<span class="mark">シリアライズ</span>されたMyLampThingTemplate</span>
 </div>
 <pre aria-busy="false"><code class="hljs json">{
     <span class="hljs-attr">"@context"</span>: [<span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>], 
@@ -5611,10 +5615,10 @@
 </section>
 <section id="buzzer-thing-template">
 
-<h4 id="c-1-2-thing-description-template-buzzer"><bdi class="secno">C.1.2</bdi> モノの記述テンプレート: ブザー<a class="self-link" aria-label="§" href="#buzzer-thing-template"></a></h4>
+<h4 id="c-1-2-thing-description-template-buzzer"><bdi class="secno">C.1.2</bdi> <span class="mark">Thing Description</span>テンプレート: ブザー<a class="self-link" aria-label="§" href="#buzzer-thing-template"></a></h4>
 
 <div class="example" id="example-37-mybuzzerthingtemplate-serialized-in-json">
-<div class="marker"><a class="self-link" href="#example-37-mybuzzerthingtemplate-serialized-in-json">例<bdi>37</bdi></a><span class="example-title">: JSONでシリアル化されたMyBuzzerThingTemplate</span></div>
+<div class="marker"><a class="self-link" href="#example-37-mybuzzerthingtemplate-serialized-in-json">例<bdi>37</bdi></a><span class="example-title">: JSONで<span class="mark">シリアライズ</span>されたMyBuzzerThingTemplate</span></div>
 <pre aria-busy="false"><code class="hljs json">{
     <span class="hljs-attr">"@context"</span>: [<span class="hljs-string">"https://www.w3.org/2019/wot/td/v1"</span>], 
     <span class="hljs-attr">"@type"</span> : <span class="hljs-string">"ThingTemplate"</span>,
@@ -5634,17 +5638,17 @@
 
 <h2 id="d-json-ld-context-usage"><bdi class="secno">D.</bdi> JSON-LDコンテキストの使用法<a class="self-link" aria-label="§" href="#json-ld-ctx-usage"></a></h2>
 
-<p><em>この項は非規範的です。</em></p>
+<p><em>この項は非規範的である。</em></p>
 
-<p>現在の仕様では、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>を様々な<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>に対する制約の集合、つまり<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の集合として導入しています。この項では、TDドキュメントの必須の<code>@context</code>を用いて、これらの制約の機械可読な定義をクライアント・アプリケーションに統合する方法について簡単に説明します。</p>
+<p>現在の仕様では、<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>を様々な<a href="#dfn-vocab" class="internalDFN" data-link-type="dfn">語彙</a>に対する制約の集合、つまり<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>の集合として導入している。この項では、TDドキュメントの必須の<code>@context</code>を用いて、これらの制約の機械可読な定義をクライアントアプリケーションに統合する方法について簡単に説明する。</p>
 
-<p>TDドキュメントから<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>へのアクセスは、2つのステップで実行されます。最初に、クライアントはJSON文字列からIRIへのマッピングを取得する必要があります。このマッピングは、後で説明するとおり、JSON-LDコンテキストとして定義されます。次に、クライアントは、このIRIを逆参照することにより、これらのIRIで定義されている制約にアクセスできます。制約は、RDF形式の論理公理として定義され、クライアント・プログラムが容易に解釈できます。</p>
+<p>TDドキュメントから<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>へのアクセスは、2つのステップで実行される。最初に、クライアントはJSON文字列からIRIへのマッピングを取得する必要がある。このマッピングは、後で説明するとおり、JSON-LDコンテキストとして定義される。次に、クライアントは、このIRIを逆参照することにより、これらのIRIで定義されている制約にアクセスできる。制約は、RDF形式の論理公理として定義され、クライアントプログラムが容易に解釈できる。</p>
 
-<p><a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で参照しているすべての<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>は、TDドキュメント内の(コンパクトな)JSON文字列としてシリアル化されています。しかし、これらの各用語は、最初のリンクト・データ原則[<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>]に従って、完全なIRIによって明確に識別されます。JSONキーからIRIへのマッピングは、TDの<code>@context</code>値が指し示すものです。例えば、次のファイル</p>
+<p><a href="#sec-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.</bdi> TD情報モデル</a>で参照しているすべての<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>は、TDドキュメント内の(コンパクトな)JSON文字列として<span class="mark">シリアライズ</span>されている。しかし、これらの各用語は、最初のリンクトデータ原則[<cite><a class="bibref" data-link-type="biblio" href="#bib-linked-data" title="Linked Data Design Issues">LINKED-DATA</a></cite>]に従って、完全なIRIによって明確に識別される。JSONキーからIRIへのマッピングは、TDの<code>@context</code>値が指し示すものである。例えば、次のファイル</p>
 
 <p><code>https://www.w3.org/2019/wot/td/v1</code></p>
 
-<p>には、次(抜粋)のマッピングが含まれています。</p>
+<p>には、次(抜粋)のマッピングが含まれている。</p>
 
 <table>
 <tbody>
@@ -5674,33 +5678,33 @@
 </tbody>
 </table>
 
-<p>このJSONファイルは、JSON-LD 1.1構文[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>]に従います。多数のJSON-LDライブラリがTDの<code>@context</code>を自動的に処理し、それに含まれているすべてのJSON文字列を展開できます。</p>
+<p>このJSONファイルは、JSON-LD 1.1構文[<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>]に従う。多数のJSON-LDライブラリがTDの<code>@context</code>を自動的に処理し、それに含まれているすべてのJSON文字列を展開できる。</p>
 
-<p>TDのすべての<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>がIRIに展開されると、次のステップは、このIRIを逆参照して、その<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を参照する<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のフラグメントを取得することです。例えば、次のIRIを逆参照すると、</p>
+<p>TDのすべての<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>がIRIに展開されると、次のステップは、このIRIを逆参照して、その<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>を参照する<a href="#dfn-inf-model" class="internalDFN" data-link-type="dfn">TD情報モデル</a>のフラグメントを取得することである。例えば、次のIRIを逆参照すると、</p>
 
 <p><code>https://www.w3.org/2019/wot/json-schema#ObjectSchema</code></p>
 
-<p><code>ObjectSchema</code>という用語は<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>であり、より正確には<code>DataSchema</code>のサブクラスであると述べるRDFドキュメントが作成されます。このような論理公理は、様々な複雑さの形式を用いてRDFで表されます。ここでは、サブクラス関係はRDFスキーマ公理[<cite><a class="bibref" data-link-type="biblio" href="#bib-rdf-schema" title="RDF Schema 1.1">RDF-SCHEMA</a></cite>]として表しています。さらに、これらの公理は様々な形式でシリアル化できます。ここでは、それらはTurtle形式[<cite><a class="bibref" data-link-type="biblio" href="#bib-turtle" title="RDF 1.1 Turtle">TURTLE</a></cite>]でシリアル化しています。</p>
+<p><code>ObjectSchema</code>という用語は<a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>であり、より正確には<code>DataSchema</code>のサブクラスであると述べるRDFドキュメントが作成される。このような論理公理は、様々な複雑さの形式を用いてRDFで表される。ここでは、サブクラス関係はRDFスキーマ公理[<cite><a class="bibref" data-link-type="biblio" href="#bib-rdf-schema" title="RDF Schema 1.1">RDF-SCHEMA</a></cite>]として表している。さらに、これらの公理は様々な形式で<span class="mark">シリアライズ</span>できる。ここでは、それらはTurtle形式[<cite><a class="bibref" data-link-type="biblio" href="#bib-turtle" title="RDF 1.1 Turtle">TURTLE</a></cite>]で<span class="mark">シリアライズ</span>している。</p>
 
 <pre class="nohighlight"><code>&lt;https://www.w3.org/2019/wot/json-schema#ObjectSchema&gt;
     a rdfs:Class .
 &lt;https://www.w3.org/2019/wot/json-schema#ObjectSchema&gt;
     rdfs:subClassOf &lt;https://www.w3.org/2019/wot/json-schema#DataSchema&gt; .</code></pre>
 
-<p>デフォルトでは、ユーザ・エージェントが内容交渉を実行しない場合は、RDFドキュメントの代わりに人間が読めるHTMLドキュメントが返されます。内容交渉を行うためには、クライアントはリクエストにHTTPヘッダー<code>Accept: text/turtle</code>を含めなければなりません。</p>
+<p>デフォルトでは、ユーザエージェントが内容交渉を実行しない場合は、RDFドキュメントの代わりに人間が読めるHTMLドキュメントが返される。内容交渉を行うためには、クライアントはリクエストにHTTPヘッダー<code>Accept: text/turtle</code>を含めなければならない。</p>
 
 </section>
 <section id="changes" class="appendix">
 
 <h2 id="e-recent-specification-changes"><bdi class="secno">E.</bdi> 最近の仕様変更<a class="self-link" aria-label="§" href="#changes"></a></h2>
 
-    <section id="changes-from-proposed-recommendation-0">
+<section id="changes-from-proposed-recommendation-0">
 
 <h3 id="changes-from-proposed-recommendation"><bdi class="secno">E.1</bdi> 勧告案からの変更<a class="self-link" aria-label="§" href="#changes-from-proposed-recommendation"></a></h3>
 
 <ul>
   <li>IANAによってCoAPコンテンツ形式ID 432が割り当てられた。(<a href="#identification" class="sec-ref">§&nbsp;<bdi class="secno">6.4</bdi> 識別</a>および<a href="#content-format-section" class="sec-ref">§&nbsp;<bdi class="secno">10.2</bdi> CoAPコンテンツ形式の登録</a>を参照)。</li>
-  <li><a href="#behavior-security" class="sec-ref">§&nbsp;<bdi class="secno">8.1</bdi> セキュリティの設定</a>の項では、一部のセキュリティ・プロトコルによって求められる動的な認証情報と、モノの記述で宣言されるセキュリティ構成情報の間の対話について明確化した。</li>
+  <li><a href="#behavior-security" class="sec-ref">§&nbsp;<bdi class="secno">8.1</bdi> <span class="mark">セキュリティ構成情報</span></a>の項では、一部のセキュリティプロトコルによって求められる動的な認証情報と、<span class="mark">Thing Description</span>で宣言されるセキュリティ<span class="mark">構成情報</span>の間の相互作用について明確化した。</li>
   <li>付録<a href="#json-schema-for-validation" class="sec-ref">§&nbsp;<bdi class="secno">B.</bdi> TDのインスタンス検証用JSONスキーマ</a>の項のいくつかの誤植のインスタンスを修正した。</li>
 </ul>
 
@@ -5711,10 +5715,10 @@
 
 <ul>
   <li>リスクのある機能としていた、<code>CertSecurityScheme</code>、<code>PublicSecurityScheme</code>、<code>PoPSecurityScheme</code>、および<a href="#oauth2securityscheme"><code>OAuth2SecurityScheme</code></a>の<code>implicit</code>、<code>password</code>、<code>client</code>のフローを削除した。</li>
-  <li><a href="#sec-data-schema-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.2</bdi> データ・スキーマ語彙の定義</a>の項で、データ・スキーマとコンテンツ・タイプの関係を明確化した。</li>
-  <li><a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>の項で、操作型である<code>writemultipleproperties</code>、<code>readmultipleproperties</code>、<code>readallproperties</code>に対する<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn">利用者</a>と<a href="#dfn-thing" class="internalDFN" data-link-type="dfn">モノ</a>の予期に関して明確化した。</li>
-  <li><a href="#http-binding-assertions" class="sec-ref">§&nbsp;<bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコル・バインディング</a>の項で、デフォルト値の<code>GET</code>または<code>PUT</code>が語彙用語である<code>htv:methodName</code>に用いられるコンテキストを明確化した。</li>
-  <li>付録<a href="#myLightSensor-example-serialization" class="sec-ref">§&nbsp;<bdi class="secno">A.2</bdi> MQTTプロトコル・バインディングを用いたMyIlluminanceSensorの例</a>の項のモノの記述の例を改善し、MQTTを用いたより良い例を作成した。</li>
+  <li><a href="#sec-data-schema-vocabulary-definition" class="sec-ref">§&nbsp;<bdi class="secno">5.3.2</bdi> <span class="mark">Data Schema</span>語彙の定義</a>の項で、データスキーマとコンテンツタイプの関係を明確化した。</li>
+  <li><a href="#form-serialization-json" class="sec-ref">§&nbsp;<bdi class="secno">6.3.9</bdi> <code>forms</code>(フォーム)</a>の項で、操作型である<code>writemultipleproperties</code>、<code>readmultipleproperties</code>、<code>readallproperties</code>に対する<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>と<a href="#dfn-thing" class="internalDFN" data-link-type="dfn"><span class="mark">Thing</span></a>の予期に関して明確化した。</li>
+  <li><a href="#http-binding-assertions" class="sec-ref">§&nbsp;<bdi class="secno">8.3.1</bdi> HTTPに基づくプロトコルバインディング</a>の項で、デフォルト値の<code>GET</code>または<code>PUT</code>が語彙用語である<code>htv:methodName</code>に用いられるコンテキストを明確化した。</li>
+  <li>付録<a href="#myLightSensor-example-serialization" class="sec-ref">§&nbsp;<bdi class="secno">A.2</bdi> MQTTプロトコルバインディングを用いたMyIlluminanceSensorの例</a>の項の<span class="mark">Thing Description</span>の例を改善し、MQTTを用いたより良い例を作成した。</li>
 </ul>
 
 </section>
@@ -5722,7 +5726,7 @@
 
 <h3 id="changes-from-candidate-recommendation"><bdi class="secno">E.3</bdi> 最初の勧告候補からの変更<a class="self-link" aria-label="§" href="#changes-from-candidate-recommendation"></a></h3>
 
-<p>最初の勧告候補からの変更点は、2番目の<a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/#changes">勧告候補</a>で記述しています</p>
+<p>最初の勧告候補からの変更点は、2番目の<a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20191106/#changes">勧告候補</a>で記述している。</p>
 
 </section>
 </section>
@@ -5730,11 +5734,11 @@
 
 <h2 id="f-acknowledgements"><bdi class="secno">F.</bdi> 謝辞<a class="self-link" aria-label="§" href="#acknowledgements"></a></h2>
 
-<p>編集者は、貢献、助言、専門知識の提供に対し、Michael Koster、Michael Lagally、Kazuyuki Ashimura、Ege Korkan、Daniel Peintner、Toru Kawaguchi、Maria Poveda、Dave Raggett、Kunihiko Toumura、Takeshi Yamada、Ben Francis、Manu Sporny、Klaus Hartke、Addison Phillips、Jose M. Cantera、Tomoaki Mizushima、Soumya Kanti Datta、Benjamin Klotzに謝意を表します。</p>
+<p>編集者は、貢献、助言、専門知識の提供に対し、Michael Koster、Michael Lagally、Kazuyuki Ashimura、Ege Korkan、Daniel Peintner、Toru Kawaguchi、Maria Poveda、Dave Raggett、Kunihiko Toumura、Takeshi Yamada、Ben Francis、Manu Sporny、Klaus Hartke、Addison Phillips、Jose M. Cantera、Tomoaki Mizushima、Soumya Kanti Datta、Benjamin Klotzに謝意を表す。</p>
 
-<p>また、このドキュメントの改善につながったサポート、技術情報、提案に対し、<abbr title="World Wide Web Consortium">W3C</abbr>のスタッフ、および<abbr title="World Wide Web Consortium">W3C</abbr> Web of Things利害団体(WoT IG)とワーキンググループ(WoT WG)の現在および以前のすべての関係者にも感謝申し上げます。</p>
+<p>また、このドキュメントの改善につながったサポート、技術情報、提案に対し、<abbr title="World Wide Web Consortium">W3C</abbr>のスタッフ、および<abbr title="World Wide Web Consortium">W3C</abbr> Web of Things利害団体(WoT IG)とワーキンググループ(WoT WG)の現在および以前のすべての関係者にも感謝する。</p>
 
-<p>最後に、WoT IGの創設から2年にわたってリードし、モノの記述を含むWoT構成要素の概念にグループを導いてくれたJoerg Heuerに特に感謝申し上げます。</p>
+<p>最後に、WoT IGの創設から2年にわたってリードし、<span class="mark">Thing Description</span>を含むWoT構成要素の概念にグループを導いてくれたJoerg Heuerに特に感謝する。</p>
 
 </section>
 <section id="references" class="appendix">


### PR DESCRIPTION
・ですます調をである調に修正。
・中点を削除。
・例3と例32のタイトルは訳し忘れていたので、新たに訳した。

＜用語統一＞
訳語ルールの「技術的な用語」に含まれる用語を修正した。

- 修正した用語は基本的にハイライト表示している。「&lt;span class="mark"&gt;...&lt;/span&gt;」
- 元々「技術的な用語」のとおりに訳していたものは、修正及びハイライト表示していない。
- 「技術的な用語」にはないが、「対話」はすべて「相互作用」に修正した。

■注意が必要と思われるもの

- 「Engineering」は、頭文字が小文字のものが1つあるが、「工学」のままとした。
- 「Hypermedia Control」は、「技術的な用語」では「ハイパーメディアコントロール」となっているが、アーキテクチュアでは「ハイパーメディア制御」と訳しているため、「ハイパーメディア制御」のままとした。「技術的な用語」を修正する必要があるのではないか。
- 「Intermediary」は、「技術的な用語」では「仲介者」となっているが、アーキテクチュアでは「Intermediary」と訳している。「技術的な用語」の修正が必要ではないか。
- 「section」は、個別判断が必要なため、修正していない。
- 「WoT Architecture」は、「技術的な用語」では「WoTアーキテクチャ」となっているが、「WoT アーキテクチャ」(1スペース挿入)にする必要があるのではないか。
- 「プロパティー、アクション、イベント」などと列記されているが、頭文字が小文字のものがある。「プロパティー」などのままとした。

■「技術的な用語」は小文字で良いのではないかと思われるもの

- Engineering
- Hypermedia Control
- Legacy Device(s)　→他の用語も複数形を含むので「(s)」は不要か
- Metadata
- Privacy
- Serialization