### PR TITLE
5.3.1.5 EventAffordance の変更　（水嶌担当）

### DIFF
--- a/index.html
+++ b/index.html
@@ -1897,7 +1897,7 @@
 </tbody>
 </table>
 
-<p><code>EventAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-event">Formインスタンスが<code>EventAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>subscribeevent</code>、<code>unsubscribeevent</code>、または<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内の両方の用語のいずれかでなければならない (<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>EventAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-event">Formインスタンスが<code>EventAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内の<code>subscribeevent</code>、<code>unsubscribeevent</code>、または両方の用語のいずれかでなければならない (<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 <section id="versioninfo">

--- a/index.html
+++ b/index.html
@@ -1864,7 +1864,12 @@
 
 <h5 id="x5-3-1-5-eventaffordance"><bdi class="secno">5.3.1.5</bdi> <code>EventAffordance</code> (<span class="mark">Eventの</span>アフォーダンス) <a class="self-link" aria-label="§" href="#eventaffordance"></a></h5>
 
-<p><span class="mark">出来事</span> (例えば、オーバーヒートの警報) の情報源を記述している<span class="mark">相互作用のアフォーダンス</span>で、<span class="mark">出来事</span>データを<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に非同期でプッシュする。</p>
+<p><span class="mark">イベント</span> (例えば、オーバーヒートの警報) の出どころを記述している<span class="mark">相互作用のアフォーダンス</span>で、当該<span class="mark">イベント</span>のデータを<a href="#dfn-consumer" class="internalDFN" data-link-type="dfn"><span class="mark">Consumer</span></a>に非同期でプッシュする。</p>
+
+<div class="note" id="issue-container-generatedID">
+<div role="heading" class="ednote-title marker" id="h-ednote" aria-level="5"><span>翻訳者のメモ</span></div>
+<p>上記箇所の英語原文では「event data」に，出どころを記述している当該イベントのデータであることを示すための「the」があるべき．</p>
+</div>
 
 <table class="def">
 <thead>
@@ -1897,7 +1902,7 @@
 </tbody>
 </table>
 
-<p><code>EventAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-event">Formインスタンスが<code>EventAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内の<code>subscribeevent</code>、<code>unsubscribeevent</code>、または両方の用語のいずれかでなければならない (<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>EventAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-event">Formインスタンスが<code>EventAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>subscribeevent</code>、<code>unsubscribeevent</code>、または<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>内の両方の用語のいずれかでなければならない (<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 <section id="versioninfo">


### PR DESCRIPTION
変更点
* 「When a Form instance is within an EventAffordance instance, the value assigned to op MUST be either subscribeevent, unsubscribeevent, or both terms within an Array.」の文の最後の「Within an Array」は「 both terms」だけではなく、「either subscribeevent, unsubscribeevent, or both terms 」にかかると思うのです、変更しました。

要確認事項
* 見出しの「EventAffordance (Eventのアフォーダンス)」はそのままの「EventAffordance」だけで良いのではないか？
* 「event source」は「出来事の情報源」というより、「イベントソース」という技術用語にした方が良いのではないか？
* 同様に「event data」も「出来事のデータ」ではなく、「イベントデータ」という技術用語にした方が良いのではないか？


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-thing-description/pull/21.html" title="Last updated on Jul 15, 2021, 1:52 AM UTC (8ca79e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-thing-description/21/82e7497...8ca79e0.html" title="Last updated on Jul 15, 2021, 1:52 AM UTC (8ca79e0)">Diff</a>