### PR TITLE
5.3.1.3 PropertyAffordanceの変更提案

### DIFF
--- a/index.html
+++ b/index.html
@@ -1783,7 +1783,12 @@
 
 <h5 id="x5-3-1-3-propertyaffordance"><bdi class="secno">5.3.1.3</bdi> <code>PropertyAffordance</code> (<span class="mark">Propertyの</span>アフォーダンス) <a class="self-link" aria-label="§" href="#propertyaffordance"></a></h5>
 
-<p><span class="mark">Thing</span>の状態を公開する<span class="mark">相互作用のアフォーダンス</span>。この状態は、取得 (読み取り) でき、オプションで更新 (書き込み) できる。<span class="mark">Thing</span>は、変更後の新しい状態をプッシュすることにより、<span class="mark">Property</span>を監視可能にすることも選択できる。</p>
+<p><span class="mark">Thing</span>の状態を公開する<span class="mark">相互作用のアフォーダンス</span>。そして、この公開された状態は、取得 (読み取り) することができる。また、オプションで更新 (書き込み) することができる。<span class="mark">Thing</span>は、変更後の新しい状態をプッシュすることにより、<span class="mark">Property</span>を監視可能にすることも選択できる。</p>
+
+<div class="note" id="issue-container-generatedID">
+<div role="heading" class="ednote-title marker" id="h-ednote" aria-level="5"><span>翻訳者のメモ</span></div>
+<p>Thingから公開された state (状態) を誰が取得・更新するのかも明記すべき。基本的には、ConsumerもしくはIntermediaryが取得・更新するものであると考えられる。</p>
+</div>
 
 <table class="def">
 <thead>

--- a/index.html
+++ b/index.html
@@ -1783,7 +1783,7 @@
 
 <h5 id="x5-3-1-3-propertyaffordance"><bdi class="secno">5.3.1.3</bdi> <code>PropertyAffordance</code> (<span class="mark">Propertyの</span>アフォーダンス) <a class="self-link" aria-label="§" href="#propertyaffordance"></a></h5>
 
-<p><span class="mark">Thing</span>の状態を公開する<span class="mark">相互作用のアフォーダンス</span>。この状態は、後で取得 (読み取り) し、オプションで更新 (書き込み) できる。<span class="mark">Thing</span>は、変更後の新しい状態をプッシュすることにより、<span class="mark">Property</span>を監視可能にすることも選択できる。</p>
+<p><span class="mark">Thing</span>の状態を公開する<span class="mark">相互作用のアフォーダンス</span>。この状態は、取得 (読み取り) でき、オプションで更新 (書き込み) できる。<span class="mark">Thing</span>は、変更後の新しい状態をプッシュすることにより、<span class="mark">Property</span>を監視可能にすることも選択できる。</p>
 
 <table class="def">
 <thead>
@@ -1797,7 +1797,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-observable--PropertyAffordance">
     <td><code>observable</code></td>
-    <td><span class="mark">Thing</span>と<span class="mark">Intermediary</span>を提供する<span class="mark">Servient</span>が、この<span class="mark">Property</span>の<code>observeproperty</code>操作をサポートするプロトコルバインディングを提供すべきかどうかを示すヒント。</td>
+    <td><span class="mark">Thing</span>を提供する<span class="mark">Servient</span>と<span class="mark">Intermediary</span>が、この<span class="mark">Property</span>の<code>observeproperty</code>操作をサポートするプロトコルバインディングを提供すべきかどうかを示すヒント。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#boolean"><code>boolean</code></a></td>
   </tr>
@@ -1811,7 +1811,7 @@
 
 </div>
 
-<p><code>PropertyAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>と<code>DataSchema</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-property">Formインスタンスが<code>PropertyAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>readproperty</code>、<code>writeproperty</code>、<code>observeproperty</code>、<code>unobserveproperty</code>、またはこれらの用語の組み合わせを含でいる<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>のいずれかでなければならない (<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
+<p><code>PropertyAffordance</code>は、<code>InteractionAffordance</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>と<code>DataSchema</code><a href="#dfn-class" class="internalDFN" data-link-type="dfn">クラス</a>の<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>である。<span class="rfc2119-assertion" id="td-op-for-property">Formインスタンスが<code>PropertyAffordance</code>インスタンス内にある場合、<code>op</code>に割り当てられている値は、<code>readproperty</code>、<code>writeproperty</code>、<code>observeproperty</code>、<code>unobserveproperty</code>、またはこれらの用語の組み合わせを含んでいる<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>のいずれかでなければならない (<em class="rfc2119" title="MUST">MUST</em>)。</span></p>
 
 </section>
 <section id="actionaffordance">


### PR DESCRIPTION
・後で取得し -> 取得でき
(This state can then be retrieved)
thenを特に訳さない方が意味が分かり易いのではないかと思います。

・ThingとIntermediaryを提供するServient
 -> Thingを提供するServientとIntermediary
(Servients hosting the Thing and Intermediaries)

・含でいる配列 -> 含んでいる配列
(an Array containing)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/matsu200722/wot-thing-description/pull/22.html" title="Last updated on Jul 15, 2021, 1:32 AM UTC (95aecc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-thing-description/22/82e7497...matsu200722:95aecc0.html" title="Last updated on Jul 15, 2021, 1:32 AM UTC (95aecc0)">Diff</a>