### PR TITLE
5.3.2.6 査読案

### DIFF
--- a/index.html
+++ b/index.html
@@ -2213,7 +2213,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-properties--ObjectSchema">
     <td><code>properties</code></td>
-    <td>データスキーマの入れ子の定義。</td>
+    <td>入れ子になったデータスキーマの定義。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a>の<a href="#dfn-map" class="internalDFN" data-link-type="dfn">マップ</a></td>
   </tr>

--- a/index.html
+++ b/index.html
@@ -2199,7 +2199,7 @@
 
 <h5 id="x5-3-2-6-objectschema"><bdi class="secno">5.3.2.6</bdi> <code>ObjectSchema</code> (オブジェクトスキーマ) <a class="self-link" aria-label="§" href="#objectschema"></a></h5>
 
-<p><code>object</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>object</code>という値で示される。</p>
+<p><code>object</code>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの中の<code>type</code>に割り当てられている<code>object</code>という値により示される。</p>
 
 <table class="def">
 <thead>


### PR DESCRIPTION
-  データスキーマの入れ子の定義(Data schema nested definitions) -> 入れ子になったデータスキーマの定義

「(オブジェクトのメンバとして)入れ子になった(各データの)データスキーマの定義(群)」という意味だとおもわれますが、あまり英文から離れない形で訳しました。


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-toumura/wot-thing-description-1/pull/27.html" title="Last updated on Aug 17, 2021, 2:37 AM UTC (22041fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-thing-description/27/657e43b...k-toumura:22041fb.html" title="Last updated on Aug 17, 2021, 2:37 AM UTC (22041fb)">Diff</a>