### PR TITLE
5.3.2.2 ArraySchema (配列スキーマ) についてのコメント

### DIFF
--- a/index.html
+++ b/index.html
@@ -2090,7 +2090,7 @@
 
 <h5 id="x5-3-2-2-arrayschema"><bdi class="secno">5.3.2.2</bdi> <code>ArraySchema</code> (配列スキーマ) <a class="self-link" aria-label="§" href="#arrayschema"></a></h5>
 
-<p><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの<code>type</code>に割り当てられている<code>array</code>という値で示される。</p>
+<p><a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a>型のデータを記述するメタデータ。この<a href="#dfn-subclass" class="internalDFN" data-link-type="dfn">サブクラス</a>は、<code>DataSchema</code>インスタンスの中の<code>type</code>に割り当てられている<code>array</code>という値により示される。</p>
 
 <table class="def">
 <thead>
@@ -2104,7 +2104,7 @@
 <tbody>
   <tr class="rfc2119-table-assertion" id="td-vocab-items--ArraySchema">
     <td><code>items</code></td>
-    <td>配列の特性を定義するために用いる。</td>
+    <td>配列の特性を定義するために用いられる。</td>
     <td>オプション</td>
     <td><a href="#dataschema"><code>DataSchema</code></a>または<a href="#dataschema"><code>DataSchema</code></a>の<a href="#dfn-array" class="internalDFN" data-link-type="dfn">配列</a></td>
   </tr>

--- a/index.html
+++ b/index.html
@@ -2110,13 +2110,13 @@
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-minItems--ArraySchema">
     <td><code>minItems</code></td>
-    <td>配列内になくてはならないアイテムの最小の数を定義する。</td>
+    <td>配列内になくてはならない要素の最小の数を定義する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td>
   </tr>
   <tr class="rfc2119-table-assertion" id="td-vocab-maxItems--ArraySchema">
     <td><code>maxItems</code></td>
-    <td>配列内になくてはならないアイテムの最大の数を定義する。</td>
+    <td>配列内になくてはならない要素の最大の数を定義する。</td>
     <td>オプション</td>
     <td><a href="http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#unsignedInt"><code>unsignedInt</code></a></td>
   </tr>


### PR DESCRIPTION
・minItems、maxItemsの説明中の"アイテム"
原文のitemをアイテムと訳されていますが、配列の要素を表しているので、"要素"と訳す方が良いのではないかと思います (itemの訳語に要素は無い様子なので、悩ましいですが)。

蛇足: characteristics of an arrayは、内容的には"配列の要素のデータ型"と訳す方が読み手にとっては分かり易いのではないかと思います。


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/matsu200722/wot-thing-description/pull/28.html" title="Last updated on Aug 17, 2021, 2:46 AM UTC (592dcb9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-thing-description/28/657e43b...matsu200722:592dcb9.html" title="Last updated on Aug 17, 2021, 2:46 AM UTC (592dcb9)">Diff</a>