### PR TITLE
5.3.3.2 NoSecurityScheme (セキュリティスキームなし)の変更案

### DIFF
--- a/index.html
+++ b/index.html
@@ -2314,7 +2314,7 @@
 
 <h5 id="x5-3-3-2-nosecurityscheme"><bdi class="secno">5.3.3.2</bdi> <code>NoSecurityScheme</code> (セキュリティスキームなし) <a class="self-link" aria-label="§" href="#nosecurityscheme"></a></h5>
 
-<p><code>nosec</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別されるセキュリティ<span class="mark">構成情報</span> (つまり、<code>"scheme": "nosec"</code>) で、リソースへのアクセスに認証やその他のメカニズムが必要ないことを示す。</p>
+<p><code>nosec</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a> (つまり、<code>"scheme": "nosec"</code>) で識別されるセキュリティ<span class="mark">構成情報</span>で、リソースへのアクセスに認証やその他のメカニズムが必要ないことを示す。</p>
 
 </section>
 <section id="basicsecurityscheme">


### PR DESCRIPTION
・nosecという語彙用語で識別されるセキュリティ構成情報 (つまり、"scheme": "nosec") で
->
nosecという語彙用語 (つまり、"scheme": "nosec") で識別されるセキュリティ構成情報で

原文の"A security configuration corresponding to identified by the Vocabulary Term nosec (i.e., "scheme": "nosec")"から、(i.e. ..)はthe Vocabulary Term nosecの直後に配置する方が良いのではないかと思います。