### PR TITLE
5.3.3.3の変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -2321,7 +2321,7 @@
 
 <h5 id="x5-3-3-3-basicsecurityscheme"><bdi class="secno">5.3.3.3</bdi> <code>BasicSecurityScheme</code> (基本セキュリティスキーム) <a class="self-link" aria-label="§" href="#basicsecurityscheme"></a></h5>
 
-<p><code>basic</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>で識別される基本認証 [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>] セキュリティ<span class="mark">構成情報</span> (つまり、<code>"scheme": "basic"</code>) で、暗号化されていないユーザ名とパスワードを用いる。このスキームは、例えば、TLSなどの機密性を提供する他のセキュリティメカニズムとともに用いるべきである。</p>
+<p>基本認証 [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7617" title="The 'Basic' HTTP Authentication Scheme">RFC7617</a></cite>] のセキュリティ<span class="mark">構成情報</span> は、暗号化されていないユーザ名とパスワードを用いる<code>basic</code>という<a href="#dfn-vocab-term" class="internalDFN" data-link-type="dfn">語彙用語</a>(つまり、<code>"scheme": "basic"</code>) で識別される。このスキームは、例えば、TLSなどの機密性を提供する他のセキュリティメカニズムとともに用いるべきである。</p>
 
 <table class="def">
 <thead>


### PR DESCRIPTION
* 多分、原文に間違いがあるようです。「Basic Authentication [RFC7617] security configuration identified by the Vocabulary Term basic (i.e., "scheme": "basic"), using an unencrypted username and password.」の部分で「identified」の前に「is」が抜けているのではないかと思います。翻訳では「is」が入れた形で翻訳しています。
* 変更をしていないのですが、表の説明の部分で「query」、「header」、「cookie」を訳した方がいいのかがわかりませんでした。


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-thing-description/pull/39.html" title="Last updated on Aug 31, 2021, 1:16 AM UTC (04b66e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/wot-jp-community/wot-thing-description/39/0cd14be...04b66e0.html" title="Last updated on Aug 31, 2021, 1:16 AM UTC (04b66e0)">Diff</a>